### PR TITLE
enhance(client): tabler icons v2

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,7 +20,7 @@ gulp.task('copy:client:fonts', () =>
 );
 
 gulp.task('copy:client:tabler-icons', () =>
-	gulp.src('./packages/client/node_modules/@tabler/icons/iconfont/**/*').pipe(gulp.dest('./built/_client_dist_/tabler-icons/'))
+	gulp.src('./packages/client/node_modules/@tabler/icons-webfont/**').pipe(gulp.dest('./built/_client_dist_/tabler-icons/'))
 );
 
 gulp.task('copy:client:locales', cb => {

--- a/packages/backend/src/server/web/views/base.pug
+++ b/packages/backend/src/server/web/views/base.pug
@@ -34,7 +34,7 @@ html
 		link(rel='prefetch' href='https://xn--931a.moe/assets/info.jpg')
 		link(rel='prefetch' href='https://xn--931a.moe/assets/not-found.jpg')
 		link(rel='prefetch' href='https://xn--931a.moe/assets/error.jpg')
-		link(rel='stylesheet' href='/assets/tabler-icons/tabler-icons.css')
+		link(rel='stylesheet' href='/assets/tabler-icons/tabler-icons.min.css')
 		link(rel='modulepreload' href=`/assets/${clientEntry.file}`)
 
 		each href in clientEntry.css

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -15,7 +15,7 @@
 		"@rollup/plugin-json": "6.0.0",
 		"@rollup/pluginutils": "5.0.2",
 		"@syuilo/aiscript": "0.11.1",
-		"@tabler/icons": "^1.117.0",
+		"@tabler/icons-webfont": "^2.4.0",
 		"@vitejs/plugin-vue": "4.0.0",
 		"@vue/compiler-sfc": "3.2.45",
 		"autobind-decorator": "2.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -370,7 +370,7 @@ importers:
       '@rollup/plugin-json': 6.0.0
       '@rollup/pluginutils': 5.0.2
       '@syuilo/aiscript': 0.11.1
-      '@tabler/icons': ^1.117.0
+      '@tabler/icons-webfont': ^2.4.0
       '@types/escape-regexp': 0.0.1
       '@types/glob': 8.0.0
       '@types/gulp': 4.0.9
@@ -445,7 +445,7 @@ importers:
       '@rollup/plugin-json': 6.0.0_rollup@2.79.0
       '@rollup/pluginutils': 5.0.2_rollup@2.79.0
       '@syuilo/aiscript': 0.11.1
-      '@tabler/icons': 1.119.0
+      '@tabler/icons-webfont': 2.4.0
       '@vitejs/plugin-vue': 4.0.0_vite@3.1.0+vue@3.2.39
       '@vue/compiler-sfc': 3.2.45
       autobind-decorator: 2.4.0
@@ -1427,16 +1427,14 @@ packages:
       defer-to-connect: 2.0.1
     dev: false
 
-  /@tabler/icons/1.119.0:
-    resolution: {integrity: sha512-Fk3Qq4w2SXcTjc/n1cuL5bccPkylrOMo7cYpQIf/yw6zP76LQV9dtLcHQUjFiUnaYuswR645CnURIhlafyAh9g==}
-    peerDependencies:
-      react: ^16.x || 17.x || 18.x
-      react-dom: ^16.x || 17.x || 18.x
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
+  /@tabler/icons-webfont/2.4.0:
+    resolution: {integrity: sha512-MAedcyLTeUoIPiZJr70s/9NrCcav7F/gsxVQ17CSWlfd8JScxQYmbt1j6uGqh4+6v85OyoWkQC/pihA59vrcvA==}
+    dependencies:
+      '@tabler/icons': 2.4.0
+    dev: false
+
+  /@tabler/icons/2.4.0:
+    resolution: {integrity: sha512-JZY9Kk3UsQoqp7Rw/BuWw1PrkRwv5h0psjJBbj+Cn9UVyhdzr5vztg2mywXBAJ+jFBUL/pjnVcIvOzKFw4CXng==}
     dev: false
 
   /@tensorflow/tfjs-backend-cpu/3.20.0_au2niqrxqvhsnv4oetlud656gy:


### PR DESCRIPTION
# What
[@tabler/icons](https://www.npmjs.com/package/@tabler/icons)を[@tabler/icons-webfont](https://www.npmjs.com/package/@tabler/icons-webfont)に変更してv2対応させた

# Why
[shield-filled](https://tabler-icons.io/i/shield-filled) を管理者用のアイコンとして使いたい(https://github.com/taiyme/misskey/issues/7)

