### PR TITLE
allow admin to view user's all notes

### DIFF
--- a/packages/backend/src/models/repositories/note.ts
+++ b/packages/backend/src/models/repositories/note.ts
@@ -190,7 +190,7 @@ export const NoteRepository = db.getRepository(Note).extend({
 
 	async pack(
 		src: Note['id'] | Note,
-		me?: { id: User['id'] } | null | undefined,
+		me?: { id: User['id'], isAdmin: User['isAdmin'] } | null | undefined,
 		options?: {
 			detail?: boolean;
 			skipHide?: boolean;
@@ -290,7 +290,7 @@ export const NoteRepository = db.getRepository(Note).extend({
 			packed.text = mfm.toString(tokens);
 		}
 
-		if (!opts.skipHide) {
+		if (!opts.skipHide && !me?.isAdmin) {
 			await hideNote(packed, meId);
 		}
 
@@ -299,7 +299,7 @@ export const NoteRepository = db.getRepository(Note).extend({
 
 	async packMany(
 		notes: Note[],
-		me?: { id: User['id'] } | null | undefined,
+		me?: { id: User['id'], isAdmin: User['isAdmin'] } | null | undefined,
 		options?: {
 			detail?: boolean;
 			skipHide?: boolean;

--- a/packages/backend/src/server/api/endpoints/users/notes.ts
+++ b/packages/backend/src/server/api/endpoints/users/notes.ts
@@ -75,7 +75,9 @@ export default define(meta, paramDef, async (ps, me) => {
 		.leftJoinAndSelect('renoteUser.avatar', 'renoteUserAvatar')
 		.leftJoinAndSelect('renoteUser.banner', 'renoteUserBanner');
 
-	generateVisibilityQuery(query, me);
+	if (me == null || !me.isAdmin) { 
+		generateVisibilityQuery(query, me);
+	}
 	if (me) {
 		generateMutedUserQuery(query, me, user);
 		generateBlockedUserQuery(query, me);


### PR DESCRIPTION
admin権限を有しているユーザーが、任意のユーザーのプロフィールを見たときに、フォロワー限定やダイレクトを含むすべてのノートを表示するようにした