### PR TITLE
feat(frontend): botアカウントでログイン時にその旨を知らせる表示を追加

### DIFF
--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -897,6 +897,8 @@ account: "アカウント"
 move: "移動"
 windowMaximize: "最大化"
 windowRestore: "元に戻す"
+caption: "キャプション"
+loggedInAsBot: "Botアカウントでログイン中"
 thisPostMayBeAnnoying: "この投稿は迷惑になる可能性があります。"
 
 _sensitiveMediaDetection:

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -897,7 +897,6 @@ account: "アカウント"
 move: "移動"
 windowMaximize: "最大化"
 windowRestore: "元に戻す"
-caption: "キャプション"
 loggedInAsBot: "Botアカウントでログイン中"
 thisPostMayBeAnnoying: "この投稿は迷惑になる可能性があります。"
 

--- a/packages/client/src/ui/_common_/common.vue
+++ b/packages/client/src/ui/_common_/common.vue
@@ -18,6 +18,8 @@
 <div v-if="pendingApiRequestsCount > 0" id="wait"></div>
 
 <div v-if="dev" id="devTicker"><span>DEV BUILD</span></div>
+
+<div v-if="$i && $i.isBot" id="botWarn"><span>{{ i18n.ts.loggedInAsBot }}</span></div>
 </template>
 
 <script lang="ts" setup>
@@ -30,6 +32,7 @@ import { uploads } from '@/scripts/upload';
 import * as sound from '@/scripts/sound';
 import { $i } from '@/account';
 import { stream } from '@/stream';
+import { i18n } from '@/i18n';
 
 const XStreamIndicator = defineAsyncComponent(() => import('./stream-indicator.vue'));
 const XUpload = defineAsyncComponent(() => import('./upload.vue'));
@@ -146,6 +149,29 @@ if ($i) {
 		border-left-color: var(--accent);
 		border-radius: 50%;
 		animation: progress-spinner 400ms linear infinite;
+	}
+}
+
+#botWarn {
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	margin: auto;
+	width: 100%;
+	height: max-content;
+	text-align: center;
+	z-index: 2147483647;
+	color: #ff0;
+	background: rgba(0, 0, 0, 0.5);
+	padding: 4px 7px;
+	font-size: 14px;
+	pointer-events: none;
+	user-select: none;
+
+	> span {
+		animation: dev-ticker-blink 2s infinite;
 	}
 }
 


### PR DESCRIPTION
# What
botアカウントでログイン時に以下の画像のような表示が出るようにした
![image](https://user-images.githubusercontent.com/86540016/227723979-107f34bc-56b2-4e59-8e0c-a8f08c56b4c2.png)


# Why
- botアカウントであることを知らせるため
- わざとbotアカウントに設定している人に「お前はbotではない」ということを知らしめるため
