### PR TITLE
fix/enhance(sw): プッシュ通知関係 (misskey-dev#9977)

### DIFF
--- a/packages/sw/src/sw.ts
+++ b/packages/sw/src/sw.ts
@@ -55,9 +55,6 @@ self.addEventListener('push', ev => {
 				// 1日以上経過している場合は無視
 				if ((new Date()).getTime() - data.dateTime > 1000 * 60 * 60 * 24) break;
 
-				// クライアントがあったらストリームに接続しているということなので通知しない
-				if (clients.length !== 0) break;
-
 				return createNotification(data);
 			case 'readAllNotifications':
 				for (const n of await self.registration.getNotifications()) {
@@ -89,7 +86,8 @@ self.addEventListener('push', ev => {
 				break;
 		}
 
-		return createEmptyNotification();
+		await createEmptyNotification();
+		return;
 	}));
 });
 


### PR DESCRIPTION
# What
リアクション通知は1つのノートにつき1つしか表示しない
Safari対応で、通知tagは能動的に閉じるように
クライアントがあってもpush notificationを無視しない

# Why
「プッシュ通知を更新しました」としか表示されず、通知内容が確認できないのを直す
(https://github.com/misskey-dev/misskey/pull/9977)
resolve #116

