### PR TITLE
fix: リリース時にバージョン情報が更新されない不具合を修正

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -160,8 +160,8 @@ jobs:
     with:
       tag: ${{ needs.get_new_version.outputs.new_version }}
 
-  commit_tag_merge_push:
-    name: Commit, Tag, Merge and Push
+  commit_tag_push:
+    name: Commit, Tag and Push
     needs:
       - get_new_version
       - update_package_json
@@ -193,6 +193,12 @@ jobs:
           git tag "${{ needs.get_new_version.outputs.new_version }}"
           git push origin HEAD --follow-tags
 
+  merge_pr:
+    name: Merge Pull request
+    needs:
+      - commit_tag_push
+    runs-on: ubuntu-latest
+    steps:
       - name: merge PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -203,7 +209,7 @@ jobs:
     needs:
       - get_new_version
       - update_changelog_md
-      - commit_tag_merge_push
+      - merge_pr
       - docker_build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -171,6 +171,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
 
       - name: Download files
         uses: actions/download-artifact@v3
@@ -190,6 +192,11 @@ jobs:
           git commit --author=. -m "${{ needs.get_new_version.outputs.new_version }}"
           git tag "${{ needs.get_new_version.outputs.new_version }}"
           git push --follow-tags
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
 
       - name: merge PR
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -191,12 +191,7 @@ jobs:
           git add .
           git commit --author=. -m "${{ needs.get_new_version.outputs.new_version }}"
           git tag "${{ needs.get_new_version.outputs.new_version }}"
-          git push --follow-tags
-
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.head_ref }}
+          git push origin HEAD --follow-tags
 
       - name: merge PR
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,8 @@ jobs:
   get_new_version:
     name: Get new version
     runs-on: ubuntu-latest
-    needs: [check_label]
+    needs:
+      - check_label
     outputs:
       new_version: ${{ steps.new_version.outputs.result }}
     steps:
@@ -75,7 +76,8 @@ jobs:
   update_package_json:
     name: Update package.json
     runs-on: ubuntu-latest
-    needs: [get_new_version]
+    needs:
+      - get_new_version
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -92,7 +94,8 @@ jobs:
   update_docker_compose_yml:
     name: Update docker-compose.yml
     runs-on: ubuntu-latest
-    needs: [get_new_version]
+    needs:
+      - get_new_version
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -109,7 +112,8 @@ jobs:
   update_changelog_md:
     name: Update CHANGELOG.md
     runs-on: ubuntu-latest
-    needs: [get_new_version]
+    needs:
+      - get_new_version
     outputs:
       changelog_body: ${{ steps.get_changelog_body.outputs.result }}
     steps:
@@ -158,13 +162,15 @@ jobs:
 
   commit_tag_merge_push:
     name: Commit, Tag, Merge and Push
-    needs: [get_new_version, update_package_json, update_docker_compose_yml, update_changelog_md]
+    needs:
+      - get_new_version
+      - update_package_json
+      - update_docker_compose_yml
+      - update_changelog_md
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.head_ref }}
 
       - name: Download files
         uses: actions/download-artifact@v3
@@ -192,7 +198,11 @@ jobs:
 
   release:
     name: Release
-    needs: [get_new_version, update_changelog_md, commit_tag_merge_push, docker_build]
+    needs:
+      - get_new_version
+      - update_changelog_md
+      - commit_tag_merge_push
+      - docker_build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout release branch


### PR DESCRIPTION
# What
- 明示的にプッシュ先を指定
- githubのPRマージが早すぎるので遅延行為をするためにjobを切った