### PR TITLE
Release: 1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
 You should also include the user name that made the change.
 -->
 
+## 12.119.2-taiyme-v1.1.3 (2023/03/31)
+
+- change(frontend): タッチデバイスでのコンテキストメニューを無効化 @taiyme
+- fix(frontend): もっと見るを閉じるボタンがボトムメニューに隠れてしまう @taiyme
+- chore(frontend): tms: 見やすいリアクションの影を少し薄くする @taiyme
+- refactor(frontend): use uuid v4 @taiyme
+
 ## 12.119.2-taiyme-v1.1.2 (2023/03/30)
 
 - chore(github/workflow): ジョブの実行順を調整 @taiyme

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   web:
-    image: ghcr.io/taiyme/misskey:12.119.2-taiyme-v1.1.2
+    image: ghcr.io/taiyme/misskey:12.119.2-taiyme-v1.1.3
     restart: always
     ports:
       - 3000:3000

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "misskey",
-	"version": "12.119.2-taiyme-v1.1.2",
+	"version": "12.119.2-taiyme-v1.1.3",
 	"codename": "indigo",
 	"repository": {
 		"type": "git",

--- a/packages/client/src/components/MkDateSeparatedList.vue
+++ b/packages/client/src/components/MkDateSeparatedList.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { defineComponent, h, PropType, TransitionGroup, useCssModule } from 'vue';
+import { v4 as uuid } from 'uuid';
 import MkAd from '@/components/global/MkAd.vue';
 import { isDebuggerEnabled, stackTraceInstances } from '@/debug';
 import { i18n } from '@/i18n';
@@ -103,7 +104,7 @@ export default defineComponent({
 				const nodes = children.flatMap((node) => node ?? []);
 				const keys = new Set(nodes.map((node) => node.key));
 				if (keys.size !== nodes.length) {
-					const id = crypto.randomUUID();
+					const id = uuid();
 					const instances = stackTraceInstances();
 					os.toast(instances.reduce((a, c) => `${a} at ${c.type.name}`, `[DEBUG_6864 (${id})]: ${nodes.length - keys.size} duplicated keys found`));
 					console.warn({ id, debugId: 6864, stack: instances });

--- a/packages/client/src/components/MkDrive.file.vue
+++ b/packages/client/src/components/MkDrive.file.vue
@@ -40,6 +40,7 @@ import bytes from '@/filters/bytes';
 import * as os from '@/os';
 import { i18n } from '@/i18n';
 import { $i } from '@/account';
+import { isTouchUsing } from '@/scripts/touch';
 
 const props = withDefaults(defineProps<{
 	file: Misskey.entities.DriveFile;
@@ -101,6 +102,7 @@ function onClick(ev: MouseEvent) {
 }
 
 function onContextmenu(ev: MouseEvent) {
+	if (isTouchUsing) return;
 	os.contextMenu(getMenu(), ev);
 }
 

--- a/packages/client/src/components/MkDrive.folder.vue
+++ b/packages/client/src/components/MkDrive.folder.vue
@@ -33,6 +33,7 @@ import * as Misskey from 'misskey-js';
 import * as os from '@/os';
 import { i18n } from '@/i18n';
 import { defaultStore } from '@/store';
+import { isTouchUsing } from '@/scripts/touch';
 import { parseObject } from '@/scripts/tms/parse';
 
 const props = withDefaults(defineProps<{
@@ -228,6 +229,7 @@ function setAsUploadFolder() {
 }
 
 function onContextmenu(ev: MouseEvent) {
+	if (isTouchUsing) return;
 	os.contextMenu([{
 		text: i18n.ts.openInWindow,
 		icon: 'ti ti-app-window',

--- a/packages/client/src/components/MkDrive.vue
+++ b/packages/client/src/components/MkDrive.vue
@@ -105,6 +105,7 @@ import { stream } from '@/stream';
 import { defaultStore } from '@/store';
 import { i18n } from '@/i18n';
 import { uploadFile, uploads } from '@/scripts/upload';
+import { isTouchUsing } from '@/scripts/touch';
 import { parseObject } from '@/scripts/tms/parse';
 
 const props = withDefaults(defineProps<{
@@ -609,6 +610,7 @@ function showMenu(ev: MouseEvent) {
 }
 
 function onContextmenu(ev: MouseEvent) {
+	if (isTouchUsing) return;
 	os.contextMenu(getMenu(), ev);
 }
 

--- a/packages/client/src/components/MkModalPageWindow.vue
+++ b/packages/client/src/components/MkModalPageWindow.vue
@@ -30,6 +30,7 @@ import * as os from '@/os';
 import { mainRouter, routes } from '@/router';
 import { i18n } from '@/i18n';
 import { PageMetadata, provideMetadataReceiver } from '@/scripts/page-metadata';
+import { isTouchUsing } from '@/scripts/touch';
 import { Router } from '@/nirax';
 
 const props = defineProps<{
@@ -111,6 +112,7 @@ function popout() {
 }
 
 function onContextmenu(ev: MouseEvent) {
+	if (isTouchUsing) return;
 	os.contextMenu(contextmenu, ev);
 }
 </script>

--- a/packages/client/src/components/MkNote.sample.vue
+++ b/packages/client/src/components/MkNote.sample.vue
@@ -274,11 +274,11 @@ const react = ({ reaction, canToggle }: {
 		grid-template-rows: 32px;
 		align-items: center;
 		border-radius: 4px;
-		box-shadow: 0 5px 15px -5px var(--shadow);
+		box-shadow: 0 4px 14px -8px var(--shadow);
 		overflow: hidden;
 
 		&.canToggle {
-			box-shadow: 0 5px 15px -5px var(--shadow), 0 0 0 1px var(--divider); // SEE: https://dskd.jp/archives/73.html
+			box-shadow: 0 4px 14px -8px var(--shadow), 0 0 0 1px var(--divider); // SEE: https://dskd.jp/archives/73.html
 		}
 
 		&.canToggle:hover,

--- a/packages/client/src/components/MkNote.vue
+++ b/packages/client/src/components/MkNote.vue
@@ -260,6 +260,7 @@ const undoReact = (note_: misskey.entities.Note): void => {
 const currentClipPage = inject<Ref<misskey.entities.Clip> | null>('currentClipPage', null);
 
 const onContextmenu = (ev: MouseEvent): void => {
+	if (isTouchUsing) return;
 	const isLink = (elem: HTMLElement): boolean => {
 		if (elem.tagName === 'A') return true;
 		if (elem.parentElement) {

--- a/packages/client/src/components/MkNote.vue
+++ b/packages/client/src/components/MkNote.vue
@@ -560,10 +560,12 @@ const readPromo = (): void => {
 				> .content {
 					&.isLong {
 						> .showLess {
-							width: 100%;
-							margin-top: 1em;
+							display: block;
 							position: sticky;
-							bottom: 1em;
+							bottom: var(--minBottomSpacing);
+							left: 0;
+							width: 100%;
+							height: 64px;
 
 							> span {
 								display: inline-block;

--- a/packages/client/src/components/MkNoteDetailed.vue
+++ b/packages/client/src/components/MkNoteDetailed.vue
@@ -140,6 +140,7 @@ import { i18n } from '@/i18n';
 import { getNoteMenu } from '@/scripts/get-note-menu';
 import { useNoteCapture } from '@/scripts/use-note-capture';
 import { deepClone } from '@/scripts/clone';
+import { isTouchUsing } from '@/scripts/touch';
 import { isPureRenote } from '@/scripts/tms/is-pure-renote';
 
 const props = defineProps<{
@@ -225,6 +226,7 @@ const undoReact = (note_: misskey.entities.Note): void => {
 };
 
 const onContextmenu = (ev: MouseEvent): void => {
+	if (isTouchUsing) return;
 	const isLink = (elem: HTMLElement): boolean => {
 		if (elem.tagName === 'A') return true;
 		if (elem.parentElement) {

--- a/packages/client/src/components/MkPagination.vue
+++ b/packages/client/src/components/MkPagination.vue
@@ -20,7 +20,7 @@
 	</div>
 
 	<div v-else ref="rootEl">
-		<div v-show="pagination.reversed && more" key="_more_" class="_gap" :class="$style.loadMore">
+		<div v-show="pagination.reversed && more" key="_more_ahead_" class="_gap" :class="$style.loadMore">
 			<MkButton
 				v-if="!moreFetching"
 				v-appear="(enableInfiniteScroll && !props.disableAutoLoad) ? fetchMoreAhead : null"
@@ -35,7 +35,7 @@
 			<MkLoading v-else class="loading"/>
 		</div>
 		<slot :items="items" :users="users" :fetching="fetching || moreFetching"></slot>
-		<div v-show="!pagination.reversed && more" key="_more_" class="_gap" :class="$style.loadMore">
+		<div v-show="!pagination.reversed && more" key="_more_behind_" class="_gap" :class="$style.loadMore">
 			<MkButton
 				v-if="!moreFetching"
 				v-appear="(enableInfiniteScroll && !props.disableAutoLoad) ? fetchMore : null"

--- a/packages/client/src/components/MkPostFormAttaches.vue
+++ b/packages/client/src/components/MkPostFormAttaches.vue
@@ -18,6 +18,7 @@
 import { defineComponent, defineAsyncComponent } from 'vue';
 import MkDriveFileThumbnail from '@/components/MkDriveFileThumbnail.vue';
 import * as os from '@/os';
+import { isTouchUsing } from '@/scripts/touch';
 
 export default defineComponent({
 	components: {
@@ -110,6 +111,7 @@ export default defineComponent({
 		},
 
 		showFileMenu(file, ev: MouseEvent) {
+			if (isTouchUsing) return;
 			if (this.menu) return;
 			this.menu = os.popupMenu([{
 				text: this.$ts.renameFile,

--- a/packages/client/src/components/MkReactionsViewer.reaction.vue
+++ b/packages/client/src/components/MkReactionsViewer.reaction.vue
@@ -145,11 +145,11 @@ useTooltip(buttonRef, async (showing) => {
 		grid-template-rows: 32px;
 		align-items: center;
 		border-radius: 4px;
-		box-shadow: 0 5px 15px -5px var(--shadow);
+		box-shadow: 0 4px 14px -8px var(--shadow);
 		overflow: hidden;
 
 		&.canToggle {
-			box-shadow: 0 5px 15px -5px var(--shadow), 0 0 0 1px var(--divider); // SEE: https://dskd.jp/archives/73.html
+			box-shadow: 0 4px 14px -8px var(--shadow), 0 0 0 1px var(--divider); // SEE: https://dskd.jp/archives/73.html
 		}
 
 		&.canToggle:hover,

--- a/packages/client/src/components/MkSparkle.vue
+++ b/packages/client/src/components/MkSparkle.vue
@@ -65,6 +65,7 @@
 
 <script lang="ts" setup>
 import { onMounted, onUnmounted, ref } from 'vue';
+import { v4 as uuid } from 'uuid';
 
 const particles = ref([]);
 const el = ref<HTMLElement>();
@@ -86,7 +87,7 @@ onMounted(() => {
 		const y = (Math.random() * (height.value - 64));
 		const sizeFactor = Math.random();
 		const particle = {
-			id: Math.random().toString(),
+			id: uuid(),
 			x,
 			y,
 			size: 0.2 + ((sizeFactor / 10) * 3),

--- a/packages/client/src/components/MkSubNoteContent.vue
+++ b/packages/client/src/components/MkSubNoteContent.vue
@@ -80,10 +80,12 @@ const collapsed = $computed(() => collapsedFlag.value && isLong);
 	}
 	&.isLong {
 		> .showLess {
-			width: 100%;
-			margin-top: 1em;
+			display: block;
 			position: sticky;
-			bottom: 1em;
+			bottom: var(--minBottomSpacing);
+			left: 0;
+			width: 100%;
+			height: 64px;
 
 			> span {
 				display: inline-block;

--- a/packages/client/src/components/MkUrlPreview.vue
+++ b/packages/client/src/components/MkUrlPreview.vue
@@ -76,6 +76,7 @@
 
 <script lang="ts" setup>
 import { defineAsyncComponent, onUnmounted } from 'vue';
+import { v4 as uuid } from 'uuid';
 import type { summaly } from 'summaly';
 import { url as local } from '@/config';
 import { i18n } from '@/i18n';
@@ -118,7 +119,7 @@ let player = $ref<SummalyResult['player']>({
 let playerEnabled = $ref(false);
 let tweetId = $ref<string | null>(null);
 let tweetExpanded = $ref(props.detail);
-const embedId = `embed${Math.random().toString().replace(/\D/, '')}`;
+const embedId = `embed${uuid().split('-').join('')}`;
 let tweetHeight = $ref(150);
 let unknownUrl = $ref(false);
 

--- a/packages/client/src/components/MkWidgets.vue
+++ b/packages/client/src/components/MkWidgets.vue
@@ -38,6 +38,7 @@ import MkButton from '@/components/MkButton.vue';
 import { widgets as widgetDefs } from '@/widgets';
 import * as os from '@/os';
 import { i18n } from '@/i18n';
+import { isTouchUsing } from '@/scripts/touch';
 
 const XDraggable = defineAsyncComponent(() => import('vuedraggable'));
 
@@ -90,6 +91,7 @@ const widgets_ = computed({
 });
 
 const onContextmenu = (widget: Widget, ev: MouseEvent): void => {
+	if (isTouchUsing) return;
 	if (!(ev.target instanceof HTMLElement)) return;
 
 	const isLink = (el: HTMLElement): el is HTMLAnchorElement => {

--- a/packages/client/src/components/MkWindow.vue
+++ b/packages/client/src/components/MkWindow.vue
@@ -40,6 +40,7 @@ import contains from '@/scripts/contains';
 import * as os from '@/os';
 import { MenuItem } from '@/types/menu';
 import { i18n } from '@/i18n';
+import { isTouchUsing } from '@/scripts/touch';
 
 const minHeight = 50;
 const minWidth = 250;
@@ -110,6 +111,7 @@ function onKeydown(evt: KeyboardEvent) {
 }
 
 function onContextmenu(ev: MouseEvent) {
+	if (isTouchUsing) return;
 	if (props.contextmenu) {
 		os.contextMenu(props.contextmenu, ev);
 	}

--- a/packages/client/src/components/form/input.vue
+++ b/packages/client/src/components/form/input.vue
@@ -41,6 +41,7 @@
 import { onMounted, nextTick, ref, watch, toRefs } from 'vue';
 import { debounce } from 'throttle-debounce';
 import { length } from 'stringz';
+import { v4 as uuid } from 'uuid';
 import MkButton from '@/components/MkButton.vue';
 import { useInterval } from '@/scripts/use-interval';
 import { i18n } from '@/i18n';
@@ -75,7 +76,7 @@ const emit = defineEmits<{
 
 const { modelValue, type, autofocus } = toRefs(props);
 const v = ref(modelValue.value);
-const id = Math.random().toString(); // TODO: uuid?
+const id = uuid();
 const focused = ref(false);
 const changed = ref(false);
 const invalid = ref(false);

--- a/packages/client/src/components/global/MkA.vue
+++ b/packages/client/src/components/global/MkA.vue
@@ -10,6 +10,7 @@ import * as os from '@/os';
 import { copyText } from '@/scripts/tms/clipboard';
 import { url } from '@/config';
 import { popout as popout_ } from '@/scripts/popout';
+import { isTouchUsing } from '@/scripts/touch';
 import { i18n } from '@/i18n';
 import { useRouter } from '@/router';
 
@@ -35,6 +36,7 @@ const active = $computed(() => {
 });
 
 function onContextmenu(ev) {
+	if (isTouchUsing) return;
 	const selection = window.getSelection();
 	if (selection && selection.toString() !== '') return;
 	os.contextMenu([{

--- a/packages/client/src/components/mfm.ts
+++ b/packages/client/src/components/mfm.ts
@@ -1,6 +1,7 @@
 import { VNode, defineComponent, h, PropType } from 'vue';
 import { CustomEmoji } from 'misskey-js/built/entities';
 import * as mfm from 'mfm-js';
+import { v4 as uuid } from 'uuid';
 import MkUrl from '@/components/global/MkUrl.vue';
 import MkLink from '@/components/MkLink.vue';
 import MkMention from '@/components/MkMention.vue';
@@ -262,7 +263,7 @@ export default defineComponent({
 
 				case 'url': {
 					return [h(MkUrl, {
-						key: Math.random(),
+						key: uuid(),
 						url: token.props.url,
 						rel: 'nofollow noopener',
 					})];
@@ -270,7 +271,7 @@ export default defineComponent({
 
 				case 'link': {
 					return [h(MkLink, {
-						key: Math.random(),
+						key: uuid(),
 						url: token.props.url,
 						rel: 'nofollow noopener',
 					}, genEl(token.children, [...parents, token.type]))];
@@ -278,7 +279,7 @@ export default defineComponent({
 
 				case 'mention': {
 					return [h(MkMention, {
-						key: Math.random(),
+						key: uuid(),
 						host: (token.props.host == null && this.author && this.author.host != null ? this.author.host : token.props.host) || host,
 						username: token.props.username,
 					})];
@@ -286,7 +287,7 @@ export default defineComponent({
 
 				case 'hashtag': {
 					return [h(MkA, {
-						key: Math.random(),
+						key: uuid(),
 						to: this.isNote ? `/tags/${encodeURIComponent(token.props.hashtag)}` : `/explore/tags/${encodeURIComponent(token.props.hashtag)}`,
 						style: 'color:var(--hashtag);',
 					}, `#${token.props.hashtag}`)];
@@ -294,7 +295,7 @@ export default defineComponent({
 
 				case 'blockCode': {
 					return [h(MkCode, {
-						key: Math.random(),
+						key: uuid(),
 						code: token.props.code,
 						lang: token.props.lang ?? undefined,
 					})];
@@ -302,7 +303,7 @@ export default defineComponent({
 
 				case 'inlineCode': {
 					return [h(MkCode, {
-						key: Math.random(),
+						key: uuid(),
 						code: token.props.code,
 						inline: true,
 					})];
@@ -322,7 +323,7 @@ export default defineComponent({
 
 				case 'emojiCode': {
 					return [h(MkEmoji, {
-						key: Math.random(),
+						key: uuid(),
 						emoji: `:${token.props.name}:`,
 						customEmojis: this.customEmojis,
 						normal: this.plain,
@@ -333,7 +334,7 @@ export default defineComponent({
 
 				case 'unicodeEmoji': {
 					return [h(MkEmoji, {
-						key: Math.random(),
+						key: uuid(),
 						emoji: token.props.emoji,
 						customEmojis: this.customEmojis,
 						normal: this.plain,
@@ -342,7 +343,7 @@ export default defineComponent({
 
 				case 'mathInline': {
 					return [h(MkFormula, {
-						key: Math.random(),
+						key: uuid(),
 						formula: token.props.formula,
 						block: false,
 					})];
@@ -350,7 +351,7 @@ export default defineComponent({
 
 				case 'mathBlock': {
 					return [h(MkFormula, {
-						key: Math.random(),
+						key: uuid(),
 						formula: token.props.formula,
 						block: true,
 					})];
@@ -358,7 +359,7 @@ export default defineComponent({
 
 				case 'search': {
 					return [h(MkGoogle, {
-						key: Math.random(),
+						key: uuid(),
 						q: token.props.query,
 					})];
 				}

--- a/packages/client/src/components/page/page.button.vue
+++ b/packages/client/src/components/page/page.button.vue
@@ -33,7 +33,7 @@ export default defineComponent({
 					text: this.hpml.interpolate(this.block.content)
 				});
 			} else if (this.block.action === 'resetRandom') {
-				this.hpml.updateRandomSeed(Math.random());
+				this.hpml.updateRandomSeed(Math.random().toString());
 				this.hpml.eval();
 			} else if (this.block.action === 'pushEvent') {
 				os.api('page-push', {

--- a/packages/client/src/components/page/page.vue
+++ b/packages/client/src/components/page/page.vue
@@ -25,7 +25,7 @@ export default defineComponent({
 	},
 	setup(props, ctx) {
 		const hpml = new Hpml(props.page, {
-			randomSeed: Math.random(),
+			randomSeed: Math.random().toString(),
 			visitor: $i,
 			url: url,
 			enableAiScript: !defaultStore.state.disablePagesScript

--- a/packages/client/src/pages/admin/metrics.vue
+++ b/packages/client/src/pages/admin/metrics.vue
@@ -67,6 +67,7 @@ import {
 	Tooltip,
 	SubTitle,
 } from 'chart.js';
+import { v4 as uuid } from 'uuid';
 import MkwFederation from '../../widgets/federation.vue';
 import MkButton from '@/components/MkButton.vue';
 import MkSelect from '@/components/form/select.vue';
@@ -154,13 +155,13 @@ export default defineComponent({
 			this.connection.on('stats', this.onStats);
 			this.connection.on('statsLog', this.onStatsLog);
 			this.connection.send('requestLog', {
-				id: Math.random().toString().substr(2, 8),
+				id: uuid(),
 				length: 150
 			});
 
 			this.$nextTick(() => {
 				this.queueConnection.send('requestLog', {
-					id: Math.random().toString().substr(2, 8),
+					id: uuid(),
 					length: 200
 				});
 			});

--- a/packages/client/src/pages/admin/overview.vue
+++ b/packages/client/src/pages/admin/overview.vue
@@ -159,6 +159,7 @@ import {
 } from 'chart.js';
 import { enUS } from 'date-fns/locale';
 import tinycolor from 'tinycolor2';
+import { v4 as uuid } from 'uuid';
 import XFederation from './overview.federation.vue';
 import XQueueChart from './overview.queue-chart.vue';
 import XUser from './overview.user.vue';
@@ -449,7 +450,7 @@ onMounted(async () => {
 
 	nextTick(() => {
 		queueStatsConnection.send('requestLog', {
-			id: Math.random().toString().substr(2, 8),
+			id: uuid(),
 			length: 100,
 		});
 	});

--- a/packages/client/src/pages/admin/queue.chart.vue
+++ b/packages/client/src/pages/admin/queue.chart.vue
@@ -40,6 +40,7 @@
 
 <script lang="ts" setup>
 import { markRaw, onMounted, onUnmounted, ref } from 'vue';
+import { v4 as uuid } from 'uuid';
 import XChart from './queue.chart.chart.vue';
 import number from '@/filters/number';
 import * as os from '@/os';
@@ -101,7 +102,7 @@ onMounted(() => {
 	connection.on('stats', onStats);
 	connection.on('statsLog', onStatsLog);
 	connection.send('requestLog', {
-		id: Math.random().toString().substr(2, 8),
+		id: uuid(),
 		length: 200,
 	});
 });

--- a/packages/client/src/pages/scratchpad.vue
+++ b/packages/client/src/pages/scratchpad.vue
@@ -27,6 +27,7 @@ import 'prismjs/components/prism-javascript';
 import 'prismjs/themes/prism-okaidia.css';
 import { PrismEditor } from 'vue-prism-editor';
 import 'vue-prism-editor/dist/prismeditor.min.css';
+import { v4 as uuid } from 'uuid';
 import { AiScript, parse, utils } from '@syuilo/aiscript';
 import MkContainer from '@/components/MkContainer.vue';
 import MkButton from '@/components/MkButton.vue';
@@ -65,7 +66,7 @@ async function run() {
 		},
 		out: (value) => {
 			logs.value.push({
-				id: Math.random(),
+				id: uuid(),
 				text: value.type === 'str' ? value.value : utils.valToString(value),
 				print: true,
 			});
@@ -73,7 +74,7 @@ async function run() {
 		log: (type, params) => {
 			switch (type) {
 				case 'end': logs.value.push({
-					id: Math.random(),
+					id: uuid(),
 					text: utils.valToString(params.val, true),
 					print: false,
 				}); break;

--- a/packages/client/src/pages/settings/preferences-backups.vue
+++ b/packages/client/src/pages/settings/preferences-backups.vue
@@ -43,6 +43,7 @@ import { $i } from '@/account';
 import { i18n } from '@/i18n';
 import { version, host } from '@/config';
 import { definePageMetadata } from '@/scripts/page-metadata';
+import { isTouchUsing } from '@/scripts/touch';
 import { parseObject } from '@/scripts/tms/parse';
 const { t, ts } = i18n;
 
@@ -373,6 +374,7 @@ async function rename(id: string): Promise<void> {
 }
 
 function menu(ev: MouseEvent, profileId: string) {
+	if (isTouchUsing) return;
 	if (!profiles) return;
 
 	return os.popupMenu([{

--- a/packages/client/src/scripts/select-file.ts
+++ b/packages/client/src/scripts/select-file.ts
@@ -1,5 +1,6 @@
 import { ref } from 'vue';
 import { DriveFile } from 'misskey-js/built/entities';
+import { v4 as uuid } from 'uuid';
 import * as os from '@/os';
 import { stream } from '@/stream';
 import { i18n } from '@/i18n';
@@ -48,7 +49,7 @@ function select(src: any, label: string | null, multiple: boolean): Promise<Driv
 			}).then(({ canceled, result: url }) => {
 				if (canceled) return;
 
-				const marker = Math.random().toString(); // TODO: UUIDとか使う
+				const marker = uuid();
 
 				const connection = stream.useChannel('main');
 				connection.on('urlUploadFinished', urlResponse => {

--- a/packages/client/src/scripts/upload.ts
+++ b/packages/client/src/scripts/upload.ts
@@ -1,5 +1,6 @@
 import { reactive, ref } from 'vue';
 import * as Misskey from 'misskey-js';
+import { v4 as uuid } from 'uuid';
 import { readAndCompressImage } from 'browser-image-resizer';
 import { defaultStore } from '@/store';
 import { apiUrl } from '@/config';
@@ -37,7 +38,7 @@ export function uploadFile(
 	if (folder && typeof folder === 'object') folder = folder.id;
 
 	return new Promise((resolve, reject) => {
-		const id = Math.random().toString();
+		const id = uuid();
 
 		const reader = new FileReader();
 		reader.onload = async (ev) => {

--- a/packages/client/src/ui/classic.vue
+++ b/packages/client/src/ui/classic.vue
@@ -49,6 +49,7 @@ import { StickySidebar } from '@/scripts/sticky-sidebar';
 import * as os from '@/os';
 import { mainRouter } from '@/router';
 import { PageMetadata, provideMetadataReceiver } from '@/scripts/page-metadata';
+import { isTouchUsing } from '@/scripts/touch';
 import { defaultStore } from '@/store';
 import { i18n } from '@/i18n';
 const XHeaderMenu = defineAsyncComponent(() => import('./classic.header.vue'));
@@ -90,6 +91,7 @@ function top() {
 }
 
 function onContextmenu(ev: MouseEvent) {
+	if (isTouchUsing) return;
 	const isLink = (el: HTMLElement) => {
 		if (el.tagName === 'A') return true;
 		if (el.parentElement) {

--- a/packages/client/src/ui/deck.vue
+++ b/packages/client/src/ui/deck.vue
@@ -87,6 +87,7 @@ import { $i } from '@/account';
 import { i18n } from '@/i18n';
 import { mainRouter } from '@/router';
 import { unisonReload } from '@/scripts/unison-reload';
+import { isTouchUsing } from '@/scripts/touch';
 const XStatusBars = defineAsyncComponent(() => import('@/ui/_common_/statusbars.vue'));
 
 const isNoMainColumn = (): boolean => !deckStore.state.columns.some(x => x.type === 'main');
@@ -167,6 +168,7 @@ const addColumn = async (ev) => {
 };
 
 const onContextmenu = (ev) => {
+	if (isTouchUsing) return;
 	os.contextMenu([{
 		text: i18n.ts._deck.addColumn,
 		action: addColumn,

--- a/packages/client/src/ui/deck/column.vue
+++ b/packages/client/src/ui/deck/column.vue
@@ -37,6 +37,7 @@ import { onBeforeUnmount, onMounted, provide, watch } from 'vue';
 import { updateColumn, swapLeftColumn, swapRightColumn, swapUpColumn, swapDownColumn, stackLeftColumn, popRightColumn, removeColumn, swapColumn, Column } from './deck-store';
 import * as os from '@/os';
 import { i18n } from '@/i18n';
+import { isTouchUsing } from '@/scripts/touch';
 import { MenuItem } from '@/types/menu';
 
 provide('shouldHeaderThin', true);
@@ -198,6 +199,7 @@ function showSettingsMenu(ev: MouseEvent) {
 }
 
 function onContextmenu(ev: MouseEvent) {
+	if (isTouchUsing) return;
 	os.contextMenu(getMenu(), ev);
 }
 

--- a/packages/client/src/ui/deck/main-column.vue
+++ b/packages/client/src/ui/deck/main-column.vue
@@ -19,6 +19,7 @@ import * as os from '@/os';
 import { i18n } from '@/i18n';
 import { mainRouter } from '@/router';
 import { PageMetadata, provideMetadataReceiver } from '@/scripts/page-metadata';
+import { isTouchUsing } from '@/scripts/touch';
 
 defineProps<{
 	column: Column;
@@ -42,6 +43,7 @@ function back() {
 }
 */
 function onContextmenu(ev: MouseEvent) {
+	if (isTouchUsing) return;
 	if (!ev.target) return;
 
 	const isLink = (el: HTMLElement) => {

--- a/packages/client/src/ui/universal.vue
+++ b/packages/client/src/ui/universal.vue
@@ -62,6 +62,7 @@ import { $i } from '@/account';
 import { mainRouter } from '@/router';
 import { PageMetadata, provideMetadataReceiver } from '@/scripts/page-metadata';
 import { deviceKind } from '@/scripts/device-kind';
+import { isTouchUsing } from '@/scripts/touch';
 import { pushHash, trimHash } from '@/scripts/tms/url-hash';
 
 const XWidgets = defineAsyncComponent(() => import('./universal.widgets.vue'));
@@ -180,6 +181,7 @@ const closeDrawerMenu = (): void => {
 };
 
 const onContextmenu = (ev) => {
+	if (isTouchUsing) return;
 	const isLink = (el: HTMLElement) => {
 		if (el.tagName === 'A') return true;
 		if (el.parentElement) {

--- a/packages/client/src/widgets/aiscript.vue
+++ b/packages/client/src/widgets/aiscript.vue
@@ -14,6 +14,7 @@
 
 <script lang="ts" setup>
 import { ref } from 'vue';
+import { v4 as uuid } from 'uuid';
 import { AiScript, parse, utils } from '@syuilo/aiscript';
 import { useWidgetPropsManager, Widget, WidgetComponentExpose } from './widget';
 import { GetFormResultType } from '@/scripts/form';
@@ -75,7 +76,7 @@ const run = async () => {
 		},
 		out: (value) => {
 			logs.value.push({
-				id: Math.random().toString(),
+				id: uuid(),
 				text: value.type === 'str' ? value.value : utils.valToString(value),
 				print: true,
 			});
@@ -83,7 +84,7 @@ const run = async () => {
 		log: (type, params) => {
 			switch (type) {
 				case 'end': logs.value.push({
-					id: Math.random().toString(),
+					id: uuid(),
 					text: utils.valToString(params.val, true),
 					print: false,
 				}); break;

--- a/packages/client/src/widgets/job-queue.vue
+++ b/packages/client/src/widgets/job-queue.vue
@@ -47,8 +47,9 @@
 
 <script lang="ts" setup>
 import { onUnmounted, reactive } from 'vue';
-import { GetFormResultType } from '@/scripts/form';
+import { v4 as uuid } from 'uuid';
 import { useWidgetPropsManager, Widget, WidgetComponentExpose } from './widget';
+import { GetFormResultType } from '@/scripts/form';
 import { stream } from '@/stream';
 import number from '@/filters/number';
 import * as sound from '@/scripts/sound';
@@ -127,7 +128,7 @@ connection.on('stats', onStats);
 connection.on('statsLog', onStatsLog);
 
 connection.send('requestLog', {
-	id: Math.random().toString().substr(2, 8),
+	id: uuid(),
 	length: 1,
 });
 

--- a/packages/client/src/widgets/server-metric/cpu-mem.vue
+++ b/packages/client/src/widgets/server-metric/cpu-mem.vue
@@ -100,7 +100,7 @@ onMounted(() => {
 	props.connection.on('stats', onStats);
 	props.connection.on('statsLog', onStatsLog);
 	props.connection.send('requestLog', {
-		id: Math.random().toString().substr(2, 8)
+		id: uuid(),
 	});
 });
 

--- a/packages/client/src/widgets/server-metric/net.vue
+++ b/packages/client/src/widgets/server-metric/net.vue
@@ -45,6 +45,7 @@
 
 <script lang="ts" setup>
 import { onMounted, onBeforeUnmount } from 'vue';
+import { v4 as uuid } from 'uuid';
 import bytes from '@/filters/bytes';
 
 const props = defineProps<{
@@ -70,7 +71,7 @@ onMounted(() => {
 	props.connection.on('stats', onStats);
 	props.connection.on('statsLog', onStatsLog);
 	props.connection.send('requestLog', {
-		id: Math.random().toString().substr(2, 8)
+		id: uuid(),
 	});
 });
 


### PR DESCRIPTION
- change(frontend): タッチデバイスでのコンテキストメニューを無効化 @taiyme
- fix(frontend): もっと見るを閉じるボタンがボトムメニューに隠れてしまう @taiyme
- chore(frontend): tms: 見やすいリアクションの影を少し薄くする @taiyme
- refactor(frontend): use uuid v4 @taiyme