### PR TITLE
feat(tms): 設定メニューの表示モード

### DIFF
--- a/locales/index.d.ts
+++ b/locales/index.d.ts
@@ -9824,6 +9824,28 @@ export interface Locale extends ILocale {
              * これらの機能はtaiymeで独自実装したものです。
              */
             readonly "description": string;
+            readonly "_superMenuDisplayMode": {
+                /**
+                 * 設定メニューの表示モード
+                 */
+                readonly "label": string;
+                /**
+                 * 主にスマートフォン・タブレットデバイス向けの設定です。
+                 */
+                readonly "caption": string;
+                /**
+                 * デフォルト
+                 */
+                readonly "default": string;
+                /**
+                 * クラシック
+                 */
+                readonly "classic": string;
+                /**
+                 * リスト強制
+                 */
+                readonly "forceList": string;
+            };
         };
         readonly "_flags": {
             /**

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -2618,6 +2618,12 @@ _tms:
   _settings:
     title: "taiyme拡張機能"
     description: "これらの機能はtaiymeで独自実装したものです。"
+    _superMenuDisplayMode:
+      label: "設定メニューの表示モード"
+      caption: "主にスマートフォン・タブレットデバイス向けの設定です。"
+      default: "デフォルト"
+      classic: "クラシック"
+      forceList: "リスト強制"
   _flags:
     title: "taiyme実験的機能"
     description: "これらの機能はtaiymeで独自実装したものです。"

--- a/packages/frontend/src/components/MkSuperMenu.vue
+++ b/packages/frontend/src/components/MkSuperMenu.vue
@@ -4,23 +4,65 @@ SPDX-License-Identifier: AGPL-3.0-only
 -->
 
 <template>
-<div class="rrevdjwu" :class="{ grid }">
-	<div v-for="group in def" class="group">
-		<div v-if="group.title" class="title">{{ group.title }}</div>
+<div
+	:class="{
+		[$style.root]: true,
+		[$style.gridView]: !props.wideMode && tmsStore.reactiveState.superMenuDisplayMode.value === 'default',
+		[$style.listView]: !props.wideMode && tmsStore.reactiveState.superMenuDisplayMode.value === 'forceList',
+		[$style.classicView]: !props.wideMode && tmsStore.reactiveState.superMenuDisplayMode.value === 'classic',
+	}"
+>
+	<div v-for="(group, i) in props.def" :key="`group:${i}`" :class="$style.group">
+		<div v-if="group.title" :class="$style.groupTitle">{{ group.title }}</div>
 
-		<div class="items">
-			<template v-for="(item, i) in group.items">
-				<a v-if="item.type === 'a'" :href="item.href" :target="item.target" :tabindex="i" class="_button item" :class="{ danger: item.danger, active: item.active }">
-					<span v-if="item.icon" class="icon"><i :class="item.icon" class="ti-fw"></i></span>
-					<span class="text">{{ item.text }}</span>
+		<div :class="$style.items">
+			<template v-for="(item, j) in group.items">
+				<a
+					v-if="item.type === 'a'"
+					:key="`group:${i}-a:${j}`"
+					:href="item.href"
+					:target="item.target"
+					tabindex="0"
+					class="_button"
+					:class="{
+						[$style.item]: true,
+						[$style.danger]: item.danger,
+						[$style.active]: item.active,
+					}"
+				>
+					<span v-if="item.icon" :class="$style.itemIcon"><i :class="item.icon" class="ti-fw"></i></span>
+					<span :class="$style.itemText">{{ item.text }}</span>
 				</a>
-				<button v-else-if="item.type === 'button'" :tabindex="i" class="_button item" :class="{ danger: item.danger, active: item.active }" :disabled="item.active" @click="ev => item.action(ev)">
-					<span v-if="item.icon" class="icon"><i :class="item.icon" class="ti-fw"></i></span>
-					<span class="text">{{ item.text }}</span>
+				<button
+					v-else-if="item.type === 'button'"
+					:key="`group:${i}-button:${j}`"
+					tabindex="0"
+					class="_button"
+					:class="{
+						[$style.item]: true,
+						[$style.danger]: item.danger,
+						[$style.active]: item.active,
+					}"
+					:disabled="item.active"
+					@click="(ev) => item.action(ev)"
+				>
+					<span v-if="item.icon" :class="$style.itemIcon"><i :class="item.icon" class="ti-fw"></i></span>
+					<span :class="$style.itemText">{{ item.text }}</span>
 				</button>
-				<MkA v-else :to="item.to" :tabindex="i" class="_button item" :class="{ danger: item.danger, active: item.active }">
-					<span v-if="item.icon" class="icon"><i :class="item.icon" class="ti-fw"></i></span>
-					<span class="text">{{ item.text }}</span>
+				<MkA
+					v-else
+					:key="`group:${i}-link:${j}`"
+					:to="item.to"
+					tabindex="0"
+					class="_button"
+					:class="{
+						[$style.item]: true,
+						[$style.danger]: item.danger,
+						[$style.active]: item.active,
+					}"
+				>
+					<span v-if="item.icon" :class="$style.itemIcon"><i :class="item.icon" class="ti-fw"></i></span>
+					<span :class="$style.itemText">{{ item.text }}</span>
 				</MkA>
 			</template>
 		</div>
@@ -29,129 +71,175 @@ SPDX-License-Identifier: AGPL-3.0-only
 </template>
 
 <script lang="ts" setup>
-import { } from 'vue';
+import { tmsStore } from '@/tms/store.js';
+import { SuperMenuDef } from '@/types/tms/super-menu.js';
 
 const props = defineProps<{
-	def: any[];
-	grid?: boolean;
+	def: SuperMenuDef;
+	wideMode?: boolean;
 }>();
 </script>
 
-<style lang="scss" scoped>
-.rrevdjwu {
-	> .group {
+<style lang="scss" module>
+.root {
+	.group {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+
 		& + .group {
 			margin-top: 16px;
 			padding-top: 16px;
 			border-top: solid 0.5px var(--divider);
 		}
+	}
 
-		> .title {
-			opacity: 0.7;
-			margin: 0 0 8px 0;
-			font-size: 0.9em;
+	.groupTitle {
+		opacity: 0.7;
+		font-size: 0.9em;
+	}
+
+	.item {
+		display: flex;
+		gap: 8px;
+		align-items: center;
+		width: 100%;
+		box-sizing: border-box;
+		padding: 9px 8px;
+		border-radius: 9px;
+		font-size: 0.9em;
+		transition: background-color 0.1s ease;
+
+		&:hover {
+			text-decoration: none;
 		}
 
-		> .items {
-			> .item {
-				display: flex;
-				align-items: center;
-				width: 100%;
-				box-sizing: border-box;
-				padding: 9px 16px 9px 8px;
-				border-radius: 9px;
-				font-size: 0.9em;
+		&.active, &:hover, &:focus {
+			color: var(--accent);
+			background-color: var(--accentedBg);
+		}
 
-				&:hover {
-					text-decoration: none;
-					background: var(--panelHighlight);
-				}
+		&.danger {
+			color: var(--error);
+		}
+	}
 
-				&.active {
-					color: var(--accent);
-					background: var(--accentedBg);
-				}
+	.itemIcon {
+		display: block;
+		width: 20px;
+		flex-shrink: 0;
+		text-align: center;
+		opacity: 0.8;
+	}
 
-				&.danger {
-					color: var(--error);
-				}
+	.itemText {
+		display: block;
+		white-space: normal;
+		flex-shrink: 1;
+		min-width: 0;
+		overflow-wrap: anywhere;
+	}
+}
 
-				> .icon {
-					width: 32px;
-					margin-right: 2px;
-					flex-shrink: 0;
-					text-align: center;
-					opacity: 0.8;
-				}
+.gridView {
+	.group {
+		padding-right: 16px;
+		padding-left: 16px;
+	}
 
-				> .text {
-					white-space: normal;
-					padding-right: 12px;
-					flex-shrink: 1;
-				}
+	.groupTitle {
+		font-size: 1em;
+	}
 
+	.items {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(70px, 1fr));
+		gap: 16px;
+	}
+
+	.item {
+		flex-direction: column;
+		gap: 6px;
+		text-align: center;
+		padding: 0;
+
+		&.active, &:hover, &:focus {
+			background-color: transparent;
+			color: var(--accent);
+			transition: none;
+
+			> .itemIcon {
+				background-color: var(--accentedBg);
 			}
 		}
 	}
 
-	&.grid {
-		> .group {
-			& + .group {
-				padding-top: 0;
-				border-top: none;
-			}
+	.itemIcon {
+		display: grid;
+		place-content: center;
+		font-size: 1.5em;
+		width: 60px;
+		height: 60px;
+		aspect-ratio: 1;
+		background-color: var(--panel);
+		border-radius: 100%;
+		transition: background-color 0.1s ease;
+	}
 
-			margin-left: 0;
-			margin-right: 0;
+	.itemText {
+		width: 100%;
+		font-size: 0.8em;
+	}
+}
 
-			> .title {
-				font-size: 1em;
-				opacity: 0.7;
-				margin: 0 0 8px 16px;
-			}
+.classicView {
+	.group {
+		padding-right: 16px;
+		padding-left: 16px;
 
-			> .items {
-				display: grid;
-				grid-template-columns: repeat(auto-fill, minmax(70px, 1fr));
-				grid-gap: 16px;
-				padding: 0 16px;
-
-				> .item {
-					flex-direction: column;
-					text-align: center;
-					padding: 0;
-
-					&:hover {
-						text-decoration: none;
-						background: none;
-						color: var(--accent);
-
-						> .icon {
-							background: var(--accentedBg);
-						}
-					}
-
-					> .icon {
-						display: grid;
-						place-content: center;
-						margin-right: 0;
-						margin-bottom: 6px;
-						font-size: 1.5em;
-						width: 60px;
-						height: 60px;
-						aspect-ratio: 1;
-						background: var(--panel);
-						border-radius: 100%;
-					}
-
-					> .text {
-						padding-right: 0;
-						width: 100%;
-						font-size: 0.8em;
-					}
-				}
-			}
+		& + .group {
+			padding-top: 0;
+			border-top: 0;
 		}
+	}
+
+	.groupTitle {
+		font-size: 1em;
+	}
+
+	.items {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+		gap: 8px;
+	}
+
+	.item {
+		flex-direction: column;
+		gap: 12px;
+		padding: 18px 16px 16px 16px;
+		background-color: var(--panel);
+		border-radius: 8px;
+		text-align: center;
+	}
+
+	.itemIcon {
+		font-size: 1.5em;
+	}
+
+	.itemText {
+		width: 100%;
+		font-size: 0.8em;
+	}
+}
+
+.listView {
+	.groupTitle {
+		font-size: 1em;
+	}
+
+	.item {
+		font-size: 1em;
+		padding: 10px 8px;
 	}
 }
 </style>

--- a/packages/frontend/src/pages/admin/index.vue
+++ b/packages/frontend/src/pages/admin/index.vue
@@ -18,7 +18,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 						<MkInfo v-if="noMaintainerInformation" warn :class="$style.navInfo">{{ i18n.ts.noMaintainerInformationWarning }} <MkA to="/admin/settings" class="_link">{{ i18n.ts.configure }}</MkA></MkInfo>
 						<MkInfo v-if="noBotProtection" warn :class="$style.navInfo">{{ i18n.ts.noBotProtectionWarning }} <MkA to="/admin/security" class="_link">{{ i18n.ts.configure }}</MkA></MkInfo>
 						<MkInfo v-if="noEmailServer" warn :class="$style.navInfo">{{ i18n.ts.noEmailServerWarning }} <MkA to="/admin/email-settings" class="_link">{{ i18n.ts.configure }}</MkA></MkInfo>
-						<MkSuperMenu :def="menuDef" :grid="!isWide"></MkSuperMenu>
+						<MkSuperMenu :def="menuDef" :wideMode="isWide"></MkSuperMenu>
 					</div>
 				</MkSpacer>
 			</div>
@@ -42,6 +42,7 @@ import { lookupUser, lookupUserByEmail } from '@/scripts/lookup-user.js';
 import { misskeyApi } from '@/scripts/misskey-api.js';
 import { PageMetadata, definePageMetadata, provideMetadataReceiver, provideReactiveMetadata } from '@/scripts/page-metadata.js';
 import { useRouter } from '@/router/supplier.js';
+import { SuperMenuDef } from '@/types/tms/super-menu.js';
 import MkInfo from '@/components/MkInfo.vue';
 import MkSuperMenu from '@/components/MkSuperMenu.vue';
 
@@ -157,15 +158,15 @@ provideReactiveMetadata(pageMetadata);
 definePageMetadata(() => pageMetadata.value);
 
 //#region menuDef
-const menuDef = computed(() => [{
+const menuDef = computed<SuperMenuDef>(() => [{
 	title: i18n.ts.quickAction,
 	items: [{
-		type: 'button',
+		type: 'button' as const,
 		icon: 'ti ti-search',
 		text: i18n.ts.lookup,
 		action: lookup,
 	}, ...(instance.disableRegistration ? [{
-		type: 'button',
+		type: 'button' as const,
 		icon: 'ti ti-user-plus',
 		text: i18n.ts.createInviteCode,
 		action: invite,

--- a/packages/frontend/src/pages/settings/index.vue
+++ b/packages/frontend/src/pages/settings/index.vue
@@ -12,7 +12,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 				<MkSpacer :contentMax="700" :marginMin="16">
 					<div>
 						<MkInfo v-if="emailNotConfigured" warn :class="$style.navInfo">{{ i18n.ts.emailNotConfiguredWarning }} <MkA to="/settings/email" class="_link">{{ i18n.ts.configure }}</MkA></MkInfo>
-						<MkSuperMenu :def="menuDef" :grid="!isWide"></MkSuperMenu>
+						<MkSuperMenu :def="menuDef" :wideMode="isWide"></MkSuperMenu>
 					</div>
 				</MkSpacer>
 			</div>
@@ -36,6 +36,7 @@ import * as os from '@/os.js';
 import { clearCache } from '@/scripts/clear-cache.js';
 import { PageMetadata, definePageMetadata, provideMetadataReceiver, provideReactiveMetadata } from '@/scripts/page-metadata.js';
 import { useRouter } from '@/router/supplier.js';
+import { SuperMenuDef } from '@/types/tms/super-menu.js';
 import MkInfo from '@/components/MkInfo.vue';
 import MkSuperMenu from '@/components/MkSuperMenu.vue';
 
@@ -141,7 +142,7 @@ provideReactiveMetadata(pageMetadata);
 definePageMetadata(() => pageMetadata.value);
 
 //#region menuDef
-const menuDef = computed(() => [{
+const menuDef = computed<SuperMenuDef>(() => [{
 	title: i18n.ts.basicSettings,
 	items: [{
 		icon: 'ti ti-user',
@@ -257,14 +258,14 @@ const menuDef = computed(() => [{
 		to: '/settings/preferences-backups',
 		active: currentPage.value?.route.name === 'preferences-backups',
 	}, {
-		type: 'button',
+		type: 'button' as const,
 		icon: 'ti ti-trash',
 		text: i18n.ts.clearCache,
 		action: async () => {
 			await clearCache();
 		},
 	}, {
-		type: 'button',
+		type: 'button' as const,
 		icon: 'ti ti-power',
 		text: i18n.ts.logout,
 		action: async () => {

--- a/packages/frontend/src/pages/tms/settings/index.main.vue
+++ b/packages/frontend/src/pages/tms/settings/index.main.vue
@@ -5,11 +5,31 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 <template>
 <div class="_gaps_m">
+	<FormSection>
+		<template #label>{{ i18n.ts.appearance }}</template>
+		<div class="_gaps">
+			<MkSelect v-model="superMenuDisplayMode">
+				<template #label>{{ i18n.ts._tms._settings._superMenuDisplayMode.label }}</template>
+				<template #caption>{{ i18n.ts._tms._settings._superMenuDisplayMode.caption }}</template>
+				<option value="default">{{ i18n.ts._tms._settings._superMenuDisplayMode.default }}</option>
+				<option value="classic">{{ i18n.ts._tms._settings._superMenuDisplayMode.classic }}</option>
+				<option value="forceList">{{ i18n.ts._tms._settings._superMenuDisplayMode.forceList }}</option>
+			</MkSelect>
+		</div>
+	</FormSection>
 </div>
 </template>
 
 <script lang="ts" setup>
-import { readonly, ref, watch } from 'vue';
+import { computed, readonly, ref, watch } from 'vue';
+import { i18n } from '@/i18n.js';
+import { tmsStore } from '@/tms/store.js';
+import FormSection from '@/components/form/section.vue';
+import MkSelect from '@/components/MkSelect.vue';
+
+//#region 即時変更
+const superMenuDisplayMode = computed(tmsStore.makeGetterSetter('superMenuDisplayMode'));
+//#endregion
 
 const edited = ref(false);
 const changed = ref(false);

--- a/packages/frontend/src/tms/store.ts
+++ b/packages/frontend/src/tms/store.ts
@@ -10,4 +10,8 @@ import { Storage } from '@/pizzax.js';
  * tmsStore -- 独自実装した機能についてのデータを格納する
  */
 export const tmsStore = markRaw(new Storage('tmsMain', {
+	superMenuDisplayMode: {
+		where: 'deviceAccount',
+		default: 'default' as 'default' | 'classic' | 'forceList',
+	},
 }));

--- a/packages/frontend/src/types/tms/super-menu.ts
+++ b/packages/frontend/src/types/tms/super-menu.ts
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+export type SuperMenuDef = SuperMenuGroup[];
+
+export type SuperMenuGroup = {
+	title?: string;
+	items: SuperMenuItem[];
+};
+
+type SuperMenuItemBase = {
+	icon: string;
+	text: string;
+	active?: boolean;
+	danger?: boolean;
+};
+
+export type SuperMenuItemButton = SuperMenuItemBase & {
+	type: 'button';
+	action: (ev: MouseEvent) => void;
+};
+
+export type SuperMenuItemA = SuperMenuItemBase & {
+	type: 'a';
+	href: string;
+	target: string;
+};
+
+export type SuperMenuItemLink = SuperMenuItemBase & {
+	type?: 'link';
+	to: string;
+};
+
+export type SuperMenuItem = SuperMenuItemButton | SuperMenuItemA | SuperMenuItemLink;


### PR DESCRIPTION
## What
スマホUIのときに設定メニューをグリッドではなくリスト表示にする

## Why
> やー個人的にはスマホもこういう表示でいいと思うんだけどね
> ![](https://submarin.online/files/thumbnail-4a49b69c-6c0c-4ac1-bbb4-7b426f6864c6)

https://submarin.online/notes/9owxk2k3ts

## Additional info (optional)
- クラシック表示を追加 by @taiyme 

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
