### PR TITLE
fix(frontend): 1:1以外のエラー画像のアスペクト比が崩れる問題

### DIFF
--- a/packages/frontend/src/components/global/MkError.vue
+++ b/packages/frontend/src/components/global/MkError.vue
@@ -28,7 +28,6 @@ const emit = defineEmits<{
 .root {
 	padding: 32px;
 	text-align: center;
-	align-items: center;
 }
 
 .text {
@@ -41,7 +40,6 @@ const emit = defineEmits<{
 
 .img {
 	vertical-align: bottom;
-	width: 128px;
 	height: 128px;
 	margin-bottom: 16px;
 	border-radius: 16px;

--- a/packages/frontend/src/pages/invite.vue
+++ b/packages/frontend/src/pages/invite.vue
@@ -103,7 +103,6 @@ definePageMetadata(() => ({
 .root {
 	padding: 32px;
 	text-align: center;
-	align-items: center;
 }
 
 .text {
@@ -112,7 +111,6 @@ definePageMetadata(() => ({
 
 .img {
 	vertical-align: bottom;
-	width: 128px;
 	height: 128px;
 	margin-bottom: 16px;
 	border-radius: 16px;

--- a/packages/frontend/src/pages/list.vue
+++ b/packages/frontend/src/pages/list.vue
@@ -131,7 +131,6 @@ definePageMetadata(() => ({
 .root {
 	padding: 32px;
 	text-align: center;
-	align-items: center;
 }
 
 .text {
@@ -140,7 +139,6 @@ definePageMetadata(() => ({
 
 .img {
 	vertical-align: bottom;
-	width: 128px;
 	height: 128px;
 	margin-bottom: 16px;
 	border-radius: 16px;

--- a/packages/frontend/src/pages/role.vue
+++ b/packages/frontend/src/pages/role.vue
@@ -103,7 +103,6 @@ definePageMetadata(() => ({
 .root {
 	padding: 32px;
 	text-align: center;
-	align-items: center;
 }
 
 .text {
@@ -112,7 +111,6 @@ definePageMetadata(() => ({
 
 .img {
 	vertical-align: bottom;
-	width: 128px;
 	height: 128px;
 	margin-bottom: 16px;
 	border-radius: 16px;


### PR DESCRIPTION
## What

## Why
resolve #194

## Additional info (optional)

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
