### PR TITLE
fix(InstanceTicker): リモートサーバーのアイコンが初期画像になる問題

### DIFF
--- a/packages/frontend/src/components/TmsInstanceTicker.vue
+++ b/packages/frontend/src/components/TmsInstanceTicker.vue
@@ -28,7 +28,8 @@ import { type tmsStore } from '@/tms/store.js';
 export type TickerProps = {
 	readonly instance?: {
 		readonly name?: string | null;
-		readonly iconUrl?: string | null;
+		// NOTE: リモートサーバーにおいてiconUrlを参照すると意図した画像にならない https://github.com/taiyme/misskey/issues/210
+		// readonly iconUrl?: string | null;
 		readonly faviconUrl?: string | null;
 		readonly themeColor?: string | null;
 	} | null;

--- a/packages/frontend/src/scripts/tms/instance-ticker.ts
+++ b/packages/frontend/src/scripts/tms/instance-ticker.ts
@@ -22,26 +22,23 @@ export const getTickerInfo = (props: TickerProps): TickerInfo => {
 	if (props.channel != null) {
 		return {
 			name: props.channel.name,
-			iconUrl: getProxiedIconUrl(localInstance) ?? '/favicon.ico',
+			iconUrl: getProxiedImageUrlNullable(localInstance.iconUrl, 'preview') ?? '/favicon.ico',
 			themeColor: props.channel.color,
 		} as const satisfies TickerInfo;
 	}
 	if (props.instance != null) {
 		return {
 			name: props.instance.name ?? '',
-			iconUrl: getProxiedIconUrl(props.instance) ?? '/client-assets/dummy.png',
+			// NOTE: リモートサーバーにおいてiconUrlを参照すると意図した画像にならない https://github.com/taiyme/misskey/issues/210
+			iconUrl: getProxiedImageUrlNullable(props.instance.faviconUrl, 'preview') ?? '/client-assets/dummy.png',
 			themeColor: props.instance.themeColor ?? TICKER_BG_COLOR_DEFAULT,
 		} as const satisfies TickerInfo;
 	}
 	return {
 		name: localInstance.name ?? host,
-		iconUrl: getProxiedIconUrl(localInstance) ?? '/favicon.ico',
+		iconUrl: getProxiedImageUrlNullable(localInstance.iconUrl, 'preview') ?? '/favicon.ico',
 		themeColor: localInstance.themeColor ?? document.querySelector<HTMLMetaElement>('meta[name="theme-color-orig"]')?.content ?? TICKER_BG_COLOR_DEFAULT,
 	} as const satisfies TickerInfo;
-};
-
-const getProxiedIconUrl = (instance: NonNullable<TickerProps['instance']>): string | null => {
-	return getProxiedImageUrlNullable(instance.iconUrl, 'preview') ?? getProxiedImageUrlNullable(instance.faviconUrl, 'preview') ?? null;
 };
 //#endregion ticker info
 


### PR DESCRIPTION
## What

## Why
resolve #210 

## Additional info (optional)

## Checklist
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If possible) Add tests
