### PR TITLE
enhance(ui/navbar): アカウントボタンの改修

### DIFF
--- a/packages/frontend/src/components/TmsAccountButton.vue
+++ b/packages/frontend/src/components/TmsAccountButton.vue
@@ -1,0 +1,85 @@
+<!--
+SPDX-FileCopyrightText: syuilo and misskey-project
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
+<template>
+<button
+	v-if="$i != null"
+	v-tooltip.noDelay.right="`${i18n.ts.account}: @${$i.username}`"
+	:class="['_button', $style.root]"
+	@click.prevent.stop="openAccountMenu"
+	@contextmenu.prevent.stop="openAccountMenu"
+>
+	<MkAvatar
+		v-if="props.iconOnly"
+		:user="$i"
+		:class="['_ghost', $style.iconOnly]"
+	/>
+	<div
+		v-else
+		:class="['_ghost', $style.account]"
+	>
+		<MkAvatar :user="$i" :class="$style.avatar"/>
+		<MkAcct :user="$i" :class="$style.acct"/>
+		<i :class="$style.mark" class="ti ti-dots-vertical"></i>
+	</div>
+</button>
+</template>
+
+<script lang="ts" setup>
+import { $i, openAccountMenu as openAccountMenu_ } from '@/account.js';
+import { i18n } from '@/i18n.js';
+
+const props = defineProps<{
+	iconOnly?: boolean;
+}>();
+
+const openAccountMenu = (ev: MouseEvent) => {
+	openAccountMenu_({
+		withExtraOperation: true,
+	}, ev);
+};
+</script>
+
+<style lang="scss" module>
+.root {
+	box-sizing: border-box;
+	overflow: clip;
+	display: block;
+	width: 100%;
+	padding: var(--tmsAccountButton-padding, 0);
+}
+
+.iconOnly {
+	display: block;
+	margin: 0 auto;
+	width: 38px;
+	height: 38px;
+}
+
+.account {
+	overflow: clip;
+	display: flex;
+	align-items: center;
+}
+
+.avatar {
+	display: block;
+	margin: 0 8px 0 13px;
+	width: 32px;
+	height: 32px;
+}
+
+.acct {
+	display: block;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.mark {
+	display: flex;
+	margin: 0 6px 0 auto;
+}
+</style>

--- a/packages/frontend/src/components/TmsServerLogo.vue
+++ b/packages/frontend/src/components/TmsServerLogo.vue
@@ -12,13 +12,13 @@ SPDX-License-Identifier: AGPL-3.0-only
 >
 	<img
 		v-if="props.iconOnly"
-		:class="$style.iconOnly"
+		:class="['_ghost', $style.iconOnly]"
 		:src="serverRef.iconUrl"
 		:alt="serverRef.name"
 	/>
 	<div
 		v-else
-		:class="[$style.banner, { [$style.onOverlay]: serverRef.bannerUrl != null }]"
+		:class="['_ghost', $style.banner, { [$style.onOverlay]: serverRef.bannerUrl != null }]"
 		:style="{ backgroundImage: serverRef.bannerUrl != null ? `url(${ serverRef.bannerUrl })` : undefined }"
 	>
 		<div :class="$style.bannerInner">
@@ -119,7 +119,7 @@ const serverRef = computed(() => {
 }
 
 .mark {
-	display: block;
+	display: flex;
 	margin: 0 6px 0 auto;
 	color: var(--fg);
 }

--- a/packages/frontend/src/ui/_common_/navbar-for-mobile.vue
+++ b/packages/frontend/src/ui/_common_/navbar-for-mobile.vue
@@ -40,9 +40,9 @@ SPDX-License-Identifier: AGPL-3.0-only
 		<button class="_button" :class="$style.post" data-cy-open-post-form @click="os.post">
 			<i :class="$style.postIcon" class="ti ti-pencil ti-fw"></i><span style="position: relative;">{{ i18n.ts.note }}</span>
 		</button>
-		<button class="_button" :class="$style.account" @click="openAccountMenu">
-			<MkAvatar :user="$i" :class="$style.avatar"/><MkAcct :class="$style.acct" class="_nowrap" :user="$i"/>
-		</button>
+		<div :class="$style.accountButton">
+			<TmsAccountButton/>
+		</div>
 	</div>
 </div>
 </template>
@@ -51,9 +51,10 @@ SPDX-License-Identifier: AGPL-3.0-only
 import { computed, defineAsyncComponent, toRef } from 'vue';
 import * as os from '@/os.js';
 import { navbarItemDef } from '@/navbar.js';
-import { $i, openAccountMenu as openAccountMenu_ } from '@/account.js';
+import { $i } from '@/account.js';
 import { defaultStore } from '@/store.js';
 import { i18n } from '@/i18n.js';
+import TmsAccountButton from '@/components/TmsAccountButton.vue';
 import TmsServerLogo from '@/components/TmsServerLogo.vue';
 
 const menu = toRef(defaultStore.state, 'menu');
@@ -64,12 +65,6 @@ const otherMenuItemIndicated = computed(() => {
 	}
 	return false;
 });
-
-function openAccountMenu(ev: MouseEvent) {
-	openAccountMenu_({
-		withExtraOperation: true,
-	}, ev);
-}
 
 function more() {
 	os.popup(defineAsyncComponent(() => import('@/components/MkLaunchPad.vue')), {}, {
@@ -143,30 +138,8 @@ function more() {
 	width: 32px;
 }
 
-.account {
-	position: relative;
-	display: flex;
-	align-items: center;
-	padding-left: 30px;
-	width: 100%;
-	text-align: left;
-	box-sizing: border-box;
-	margin-top: 16px;
-}
-
-.avatar {
-	display: block;
-	flex-shrink: 0;
-	position: relative;
-	width: 32px;
-	aspect-ratio: 1;
-	margin-right: 8px;
-}
-
-.acct {
-	display: block;
-	flex-shrink: 1;
-	padding-right: 8px;
+.accountButton {
+	--tmsAccountButton-padding: 20px 12px;
 }
 
 .middle {

--- a/packages/frontend/src/ui/_common_/navbar.vue
+++ b/packages/frontend/src/ui/_common_/navbar.vue
@@ -50,9 +50,9 @@ SPDX-License-Identifier: AGPL-3.0-only
 			<button v-tooltip.noDelay.right="i18n.ts.note" class="_button" :class="[$style.post]" data-cy-open-post-form @click="os.post">
 				<i class="ti ti-pencil ti-fw" :class="$style.postIcon"></i><span :class="$style.postText">{{ i18n.ts.note }}</span>
 			</button>
-			<button v-tooltip.noDelay.right="`${i18n.ts.account}: @${$i.username}`" class="_button" :class="[$style.account]" @click="openAccountMenu">
-				<MkAvatar :user="$i" :class="$style.avatar"/><MkAcct class="_nowrap" :class="$style.acct" :user="$i"/>
-			</button>
+			<div :class="$style.accountButton">
+				<TmsAccountButton :iconOnly="iconOnly"/>
+			</div>
 		</div>
 	</div>
 </div>
@@ -62,9 +62,10 @@ SPDX-License-Identifier: AGPL-3.0-only
 import { computed, defineAsyncComponent, ref, watch } from 'vue';
 import * as os from '@/os.js';
 import { navbarItemDef } from '@/navbar.js';
-import { $i, openAccountMenu as openAccountMenu_ } from '@/account.js';
+import { $i } from '@/account.js';
 import { defaultStore } from '@/store.js';
 import { i18n } from '@/i18n.js';
+import TmsAccountButton from '@/components/TmsAccountButton.vue';
 import TmsServerLogo from '@/components/TmsServerLogo.vue';
 
 const iconOnly = ref(false);
@@ -89,12 +90,6 @@ window.addEventListener('resize', calcViewState);
 watch(defaultStore.reactiveState.menuDisplay, () => {
 	calcViewState();
 });
-
-function openAccountMenu(ev: MouseEvent) {
-	openAccountMenu_({
-		withExtraOperation: true,
-	}, ev);
-}
 
 function more(ev: MouseEvent) {
 	os.popup(defineAsyncComponent(() => import('@/components/MkLaunchPad.vue')), {
@@ -201,31 +196,8 @@ function more(ev: MouseEvent) {
 		position: relative;
 	}
 
-	.account {
-		position: relative;
-		display: flex;
-		align-items: center;
-		padding: 20px 0 20px 30px;
-		width: 100%;
-		text-align: left;
-		box-sizing: border-box;
-		overflow: hidden; // fallback (overflow: clip)
-		overflow: clip;
-	}
-
-	.avatar {
-		display: block;
-		flex-shrink: 0;
-		position: relative;
-		width: 32px;
-		aspect-ratio: 1;
-		margin-right: 8px;
-	}
-
-	.acct {
-		display: block;
-		flex-shrink: 1;
-		padding-right: 8px;
+	.accountButton {
+		--tmsAccountButton-padding: 20px 17px;
 	}
 
 	.middle {
@@ -375,23 +347,8 @@ function more(ev: MouseEvent) {
 		display: none;
 	}
 
-	.account {
-		display: block;
-		text-align: center;
-		padding: 20px 0;
-		width: 100%;
-		overflow: hidden; // fallback (overflow: clip)
-		overflow: clip;
-	}
-
-	.avatar {
-		display: inline-block;
-		width: 38px;
-		aspect-ratio: 1;
-	}
-
-	.acct {
-		display: none;
+	.accountButton {
+		--tmsAccountButton-padding: 20px 0px;
 	}
 
 	.middle {


### PR DESCRIPTION
## What

Before:
<img width="384" alt="enhacctbtn-before" src="https://github.com/taiyme/misskey/assets/53635909/25879f4e-2852-496c-a321-178d349112d9">

After:
<img width="384" alt="enhacctbtn-after" src="https://github.com/taiyme/misskey/assets/53635909/fcbdbe4a-dc10-4abe-ac74-c87296e4da02">

## Why

## Additional info (optional)

## Checklist
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If possible) Add tests
