### PR TITLE
enhance(abuses): 通報一覧ページの改修

### DIFF
--- a/locales/index.d.ts
+++ b/locales/index.d.ts
@@ -10009,6 +10009,14 @@ export interface Locale extends ILocale {
          * 数字引用しました
          */
         readonly "didNumberquote": string;
+        /**
+         * {user}によって解決済み
+         */
+        readonly "resolvedBy": ParameterizedString<"user">;
+        /**
+         * リモートサーバーに転送済み
+         */
+        readonly "forwardedReport": string;
         readonly "_about": {
             /**
              * taiymeについて

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -2666,6 +2666,8 @@ _tms:
   numberquote: "数字引用する"
   didPakuru: "パクりました"
   didNumberquote: "数字引用しました"
+  resolvedBy: "{user}によって解決済み"
+  forwardedReport: "リモートサーバーに転送済み"
   _about:
     title: "taiymeについて"
     description: "taiymeは、Misskeyから派生したオープンソースのソフトウェアです。"

--- a/packages/backend/src/core/entities/AbuseUserReportEntityService.ts
+++ b/packages/backend/src/core/entities/AbuseUserReportEntityService.ts
@@ -39,12 +39,15 @@ export class AbuseUserReportEntityService {
 			assigneeId: report.assigneeId,
 			reporter: this.userEntityService.pack(report.reporter ?? report.reporterId, null, {
 				schema: 'UserDetailedNotMe',
+				iAmModerator: true,
 			}),
 			targetUser: this.userEntityService.pack(report.targetUser ?? report.targetUserId, null, {
 				schema: 'UserDetailedNotMe',
+				iAmModerator: true,
 			}),
 			assignee: report.assigneeId ? this.userEntityService.pack(report.assignee ?? report.assigneeId, null, {
 				schema: 'UserDetailedNotMe',
+				iAmModerator: true,
 			}) : null,
 			forwarded: report.forwarded,
 		});

--- a/packages/backend/src/core/entities/UserEntityService.ts
+++ b/packages/backend/src/core/entities/UserEntityService.ts
@@ -404,11 +404,13 @@ export class UserEntityService implements OnModuleInit {
 			userRelations?: Map<MiUser['id'], UserRelation>,
 			userMemos?: Map<MiUser['id'], string | null>,
 			pinNotes?: Map<MiUser['id'], MiUserNotePining[]>,
+			iAmModerator?: boolean,
 		},
 	): Promise<Packed<S>> {
 		const opts = Object.assign({
 			schema: 'UserLite',
 			includeSecrets: false,
+			iAmModerator: false,
 		}, options);
 
 		const user = typeof src === 'object' ? src : await this.usersRepository.findOneByOrFail({ id: src });
@@ -416,7 +418,7 @@ export class UserEntityService implements OnModuleInit {
 		const isDetailed = opts.schema !== 'UserLite';
 		const meId = me ? me.id : null;
 		const isMe = meId === user.id;
-		const iAmModerator = me ? await this.roleService.isModerator(me as MiUser) : false;
+		const iAmModerator = opts.iAmModerator || (me ? await this.roleService.isModerator(me as MiUser) : false);
 
 		const profile = isDetailed
 			? (opts.userProfile ?? await this.userProfilesRepository.findOneByOrFail({ userId: user.id }))

--- a/packages/backend/src/server/api/endpoints/admin/abuse-user-reports.ts
+++ b/packages/backend/src/server/api/endpoints/admin/abuse-user-reports.ts
@@ -74,6 +74,10 @@ export const meta = {
 					nullable: true, optional: true,
 					ref: 'UserDetailedNotMe',
 				},
+				forwarded: {
+					type: 'boolean',
+					nullable: false, optional: false,
+				},
 			},
 		},
 	},

--- a/packages/frontend/src/pages/admin/abuses.vue
+++ b/packages/frontend/src/pages/admin/abuses.vue
@@ -30,19 +30,9 @@ SPDX-License-Identifier: AGPL-3.0-only
 							<option value="remote">{{ i18n.ts.remote }}</option>
 						</MkSelect>
 					</div>
-					<!-- TODO
-			<div class="inputs" style="display: flex; padding-top: 1.2em;">
-				<MkInput v-model="searchUsername" style="margin: 0; flex: 1;" type="text" :spellcheck="false">
-					<span>{{ i18n.ts.username }}</span>
-				</MkInput>
-				<MkInput v-model="searchHost" style="margin: 0; flex: 1;" type="text" :spellcheck="false" :disabled="pagination.params().origin === 'local'">
-					<span>{{ i18n.ts.host }}</span>
-				</MkInput>
-			</div>
-			-->
 
-					<MkPagination v-slot="{items}" ref="reports" :pagination="pagination" style="margin-top: var(--margin);">
-						<XAbuseReport v-for="report in items" :key="report.id" :report="report" @resolved="resolved"/>
+					<MkPagination v-slot="{ items }" ref="reports" :pagination="pagination" style="margin-top: var(--margin);">
+						<XAbuseReport v-for="report in (items as AbuseUserReport[])" :key="report.id" :report="report" @resolved="resolved"/>
 					</MkPagination>
 				</div>
 			</div>
@@ -52,20 +42,18 @@ SPDX-License-Identifier: AGPL-3.0-only
 </template>
 
 <script lang="ts" setup>
-import { computed, shallowRef, ref } from 'vue';
-import MkSelect from '@/components/MkSelect.vue';
-import MkPagination from '@/components/MkPagination.vue';
-import XAbuseReport from '@/components/MkAbuseReport.vue';
+import { computed, ref, shallowRef } from 'vue';
 import { i18n } from '@/i18n.js';
 import { definePageMetadata } from '@/scripts/page-metadata.js';
+import MkPagination from '@/components/MkPagination.vue';
+import MkSelect from '@/components/MkSelect.vue';
+import XAbuseReport, { type AbuseUserReport } from '@/components/MkAbuseReport.vue';
 
 const reports = shallowRef<InstanceType<typeof MkPagination>>();
 
-const state = ref('unresolved');
-const reporterOrigin = ref('combined');
-const targetUserOrigin = ref('combined');
-const searchUsername = ref('');
-const searchHost = ref('');
+const state = ref<'all' | 'unresolved' | 'resolved'>('unresolved');
+const reporterOrigin = ref<'combined' | 'local' | 'remote'>('combined');
+const targetUserOrigin = ref<'combined' | 'local' | 'remote'>('combined');
 
 const pagination = {
 	endpoint: 'admin/abuse-user-reports' as const,
@@ -77,9 +65,11 @@ const pagination = {
 	})),
 };
 
-function resolved(reportId) {
-	reports.value.removeItem(reportId);
-}
+const resolved = (reportId: string) => {
+	if (state.value === 'unresolved') {
+		reports.value?.removeItem(reportId);
+	}
+};
 
 const headerActions = computed(() => []);
 

--- a/packages/misskey-js/src/autogen/types.ts
+++ b/packages/misskey-js/src/autogen/types.ts
@@ -5080,6 +5080,7 @@ export type operations = {
               reporter: components['schemas']['UserDetailedNotMe'];
               targetUser: components['schemas']['UserDetailedNotMe'];
               assignee?: components['schemas']['UserDetailedNotMe'] | null;
+              forwarded: boolean;
             })[];
         };
       };


### PR DESCRIPTION
## What

### Before:
**解決前**
<img width="500" alt="enhabuses-before1" src="https://github.com/taiyme/misskey/assets/53635909/821f59c8-cb60-4395-bc8f-60abfc202bfa">
**解決後**
<img width="500" alt="enhabuses-before2" src="https://github.com/taiyme/misskey/assets/53635909/aed11954-e2c6-4c77-bd6c-d956f0686069">

### After:
**解決前**
<img width="500" alt="enhabuses-after1" src="https://github.com/taiyme/misskey/assets/53635909/285dc744-517c-4cba-b2dc-8fa3581d8d9e">
**解決後**
<img width="500" alt="enhabuses-after2" src="https://github.com/taiyme/misskey/assets/53635909/f7b4b8fe-ffd5-42ed-af0e-61c8d15c9d7a">

※ リモートサーバーに通報を転送する 機能はリモートユーザーにのみ利用可能です (利用可能なときだけ描画します)

## Why

## Additional info (optional)

## Checklist
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If possible) Add tests
