### PR TITLE
enh(frontend): 斜線デザインの調整, Mk.*CardMiniの改修

### DIFF
--- a/idea/MkDisableSection.vue
+++ b/idea/MkDisableSection.vue
@@ -34,8 +34,13 @@ defineProps<{
 	width: 100%;
 	height: 100%;
 	cursor: not-allowed;
-	--color: color(from var(--error) srgb r g b / 0.25);
-	background-size: auto auto;
-	background-image: repeating-linear-gradient(135deg, transparent, transparent 10px, var(--color) 4px, var(--color) 14px);
+	background-image: repeating-linear-gradient(
+		135deg,
+		transparent,
+		transparent 10px,
+		var(--c) 6px,
+		var(--c) 16px
+	);
+	--c: color(from var(--error) srgb r g b / 0.25);
 }
 </style>

--- a/packages/frontend/src/components/MkAbuseReport.vue
+++ b/packages/frontend/src/components/MkAbuseReport.vue
@@ -8,7 +8,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 	<!-- 通報されたユーザー -->
 	<div :class="[$style.item, '_gaps_s']">
 		<MkA v-user-preview="props.report.targetUser.id" :to="`/admin/user/${props.report.targetUser.id}`" :behavior="'window'">
-			<MkUserCardMini :user="props.report.targetUser" :withChart="false" :class="$style.userCard"/>
+			<MkUserCardMini :user="props.report.targetUser"/>
 		</MkA>
 		<div :class="$style.userStatus">
 			<button
@@ -259,21 +259,6 @@ const showReportMemo = () => {
 	&:empty {
 		display: none;
 	}
-}
-
-.userCard {
-	background-image: linear-gradient(
-		45deg,
-		rgba(255, 196, 0, 0.15) 16.67%,
-		transparent 16.67%,
-		transparent 50%,
-		rgba(255, 196, 0, 0.15) 50%,
-		rgba(255, 196, 0, 0.15) 66.67%,
-		transparent 66.67%,
-		transparent 100%
-	);
-	background-size: 16px 16px;
-	background-color: transparent !important;
 }
 
 .userStatus {

--- a/packages/frontend/src/components/MkCustomEmojiDetailedDialog.vue
+++ b/packages/frontend/src/components/MkCustomEmojiDetailedDialog.vue
@@ -85,10 +85,25 @@ const cancel = () => {
 .emojiImgWrapper {
 	max-width: 100%;
 	height: 40cqh;
-	background-image: repeating-linear-gradient(45deg, transparent, transparent 8px, var(--X5) 8px, var(--X5) 14px);
 	border-radius: var(--radius);
 	margin: auto;
 	overflow-y: hidden;
+	background-image: repeating-linear-gradient(
+		135deg,
+		transparent,
+		transparent 10px,
+		var(--c) 6px,
+		var(--c) 16px
+	);
+
+	&,
+	html[data-color-scheme=light] & {
+		--c: rgb(0 0 0 / 0.02);
+	}
+
+	html[data-color-scheme=dark] & {
+		--c: rgb(255 255 255 / 0.02);
+	}
 }
 
 .aliases {

--- a/packages/frontend/src/components/MkEmbedCodeGenDialog.vue
+++ b/packages/frontend/src/components/MkEmbedCodeGenDialog.vue
@@ -307,8 +307,13 @@ onUnmounted(() => {
 .embedCodeGenPreviewRoot {
 	position: relative;
 	background-color: var(--bg);
-	background-size: auto auto;
-	background-image: repeating-linear-gradient(135deg, transparent, transparent 6px, var(--panel) 6px, var(--panel) 12px);
+	background-image: repeating-linear-gradient(
+		135deg,
+		transparent,
+		transparent 10px,
+		var(--panel) 6px,
+		var(--panel) 16px
+	);
 	cursor: not-allowed;
 }
 

--- a/packages/frontend/src/components/MkFlashPreview.vue
+++ b/packages/frontend/src/components/MkFlashPreview.vue
@@ -92,9 +92,13 @@ const props = defineProps<{
 	}
 
 	&:global(.gray) {
-		--c: var(--bg);
-		background-image: linear-gradient(45deg, var(--c) 16.67%, transparent 16.67%, transparent 50%, var(--c) 50%, var(--c) 66.67%, transparent 66.67%, transparent 100%);
-		background-size: 16px 16px;
+		background-image: repeating-linear-gradient(
+			135deg,
+			transparent,
+			transparent 10px,
+			var(--bg) 6px,
+			var(--bg) 16px
+		);
 	}
 
 	@media (max-width: 700px) {

--- a/packages/frontend/src/components/MkFolder.vue
+++ b/packages/frontend/src/components/MkFolder.vue
@@ -229,8 +229,13 @@ onMounted(() => {
 	background: var(--acrylicBg);
 	-webkit-backdrop-filter: var(--blur, blur(15px));
 	backdrop-filter: var(--blur, blur(15px));
-	background-size: auto auto;
-	background-image: repeating-linear-gradient(135deg, transparent, transparent 5px, var(--panel) 5px, var(--panel) 10px);
+	background-image: repeating-linear-gradient(
+		135deg,
+		transparent,
+		transparent 10px,
+		var(--panel) 6px,
+		var(--panel) 16px
+	);
 	border-radius: 0 0 6px 6px;
 }
 </style>

--- a/packages/frontend/src/components/MkInstanceCardMini.vue
+++ b/packages/frontend/src/components/MkInstanceCardMini.vue
@@ -4,114 +4,158 @@ SPDX-License-Identifier: AGPL-3.0-only
 -->
 
 <template>
-<div :class="[$style.root, { yellow: instance.isNotResponding, red: instance.isBlocked, gray: instance.isSuspended, blue: instance.isSilenced }]">
-	<img class="icon" :src="getInstanceIcon(instance)" alt="" loading="lazy"/>
-	<div class="body">
-		<span class="host">{{ instance.name ?? instance.host }}</span>
-		<span class="sub _monospace"><b>{{ instance.host }}</b> / {{ instance.softwareName || '?' }} {{ instance.softwareVersion }}</span>
+<div
+	:class="[$style.root, {
+		[$style.isNotResponding]: instance.isNotResponding,
+		[$style.isSilenced]: instance.isSilenced,
+		[$style.isSuspended]: instance.isSuspended,
+		[$style.isBlocked]: instance.isBlocked,
+	}]"
+>
+	<img :class="$style.icon" :src="getInstanceIcon(instance)" alt="" loading="lazy"/>
+	<div :class="$style.body">
+		<span :class="$style.host">{{ instance.name || instance.host }}</span>
+		<span :class="$style.sub">
+			<span class="_monospace">
+				<span style="font-weight: 700;">{{ instance.host }}</span> / {{ instance.softwareName || '?' }} {{ instance.softwareVersion }}
+			</span>
+		</span>
 	</div>
-	<MkMiniChart v-if="chartValues" class="chart" :src="chartValues"/>
+	<MkMiniChart v-if="chartValues" :class="$style.chart" :src="chartValues"/>
 </div>
 </template>
 
 <script lang="ts" setup>
-import { ref } from 'vue';
+import { shallowRef, watch } from 'vue';
 import * as Misskey from 'misskey-js';
-import MkMiniChart from '@/components/MkMiniChart.vue';
 import { misskeyApiGet } from '@/scripts/misskey-api.js';
 import { getProxiedImageUrlNullable } from '@/scripts/media-proxy.js';
+import MkMiniChart from '@/components/MkMiniChart.vue';
 
 const props = defineProps<{
 	instance: Misskey.entities.FederationInstance;
 }>();
 
-const chartValues = ref<number[] | null>(null);
+const chartValues = shallowRef<number[] | null>(null);
 
-misskeyApiGet('charts/instance', { host: props.instance.host, limit: 16 + 1, span: 'day' }).then(res => {
-	// 今日のぶんの値はまだ途中の値であり、それも含めると大抵の場合前日よりも下降しているようなグラフになってしまうため今日は弾く
-	res.requests.received.splice(0, 1);
-	chartValues.value = res.requests.received;
+watch(() => props.instance.host, (host) => {
+	misskeyApiGet('charts/instance', {
+		host,
+		limit: 16 + 1,
+		span: 'day',
+	}).then(res => {
+		// 今日のぶんの値はまだ途中の値であり、それも含めると大抵の場合前日よりも下降しているようなグラフになってしまうため今日は弾く
+		res.requests.received.shift();
+		chartValues.value = res.requests.received;
+	}).catch(() => {
+		chartValues.value = null;
+	});
+}, {
+	immediate: true,
 });
 
-function getInstanceIcon(instance): string {
-	return getProxiedImageUrlNullable(instance.iconUrl, 'preview') ?? getProxiedImageUrlNullable(instance.faviconUrl, 'preview') ?? '/client-assets/dummy.png';
-}
+const getInstanceIcon = (instance: Misskey.entities.FederationInstance) => (
+	getProxiedImageUrlNullable(instance.iconUrl, 'preview')
+		?? getProxiedImageUrlNullable(instance.faviconUrl, 'preview')
+		?? '/client-assets/dummy.png'
+);
 </script>
 
 <style lang="scss" module>
-.root {
-	$bodyTitleHieght: 18px;
-	$bodyInfoHieght: 16px;
+$bodyTitleHieght: 18px;
+$bodyInfoHieght: 16px;
 
+.root {
 	display: flex;
 	align-items: center;
 	padding: 16px;
-	background: var(--panel);
 	border-radius: 8px;
+	background-color: var(--panel);
+	background-image: repeating-linear-gradient(
+		135deg,
+		transparent,
+		transparent 10px,
+		var(--c) 6px,
+		var(--c) 16px
+	);
+	--c: transparent;
 
-	> :global(.icon) {
-		display: block;
-		width: ($bodyTitleHieght + $bodyInfoHieght);
-		height: ($bodyTitleHieght + $bodyInfoHieght);
-		object-fit: cover;
-		border-radius: 4px;
-		margin-right: 10px;
-	}
-
-	> :global(.body) {
-		flex: 1;
-		overflow: hidden;
-		font-size: 0.9em;
-		color: var(--fg);
-		padding-right: 8px;
-
-		> :global(.host) {
-			display: block;
-			width: 100%;
-			white-space: nowrap;
-			overflow: hidden;
-			text-overflow: ellipsis;
-			line-height: $bodyTitleHieght;
+	&,
+	html[data-color-scheme=light] & {
+		&.isNotResponding {
+			--c: color(from color-mix(in srgb, var(--panel), orange 50%) srgb r g b / 0.25);
 		}
 
-		> :global(.sub) {
-			display: block;
-			width: 100%;
-			font-size: 80%;
-			opacity: 0.7;
-			line-height: $bodyInfoHieght;
-			white-space: nowrap;
-			overflow: hidden;
-			text-overflow: ellipsis;
+		&.isSilenced {
+			--c: color(from color-mix(in srgb, var(--panel), blue 50%) srgb r g b / 0.25);
+		}
+
+		&.isSuspended {
+			--c: color(from color-mix(in srgb, var(--panel), black 15%) srgb r g b / 0.25);
+		}
+
+		&.isBlocked {
+			--c: color(from color-mix(in srgb, var(--panel), red 50%) srgb r g b / 0.25);
 		}
 	}
 
-	> :global(.chart) {
-		height: 30px;
-	}
+	html[data-color-scheme=dark] & {
+		&.isNotResponding {
+			--c: color(from color-mix(in srgb, var(--panel), orange 50%) srgb r g b / 0.5);
+		}
 
-	&:global(.blue) {
-		--c: rgba(0, 42, 255, 0.15);
-		background-image: linear-gradient(45deg, var(--c) 16.67%, transparent 16.67%, transparent 50%, var(--c) 50%, var(--c) 66.67%, transparent 66.67%, transparent 100%);
-		background-size: 16px 16px;
-	}
+		&.isSilenced {
+			--c: color(from color-mix(in srgb, var(--panel), blue 50%) srgb r g b / 0.5);
+		}
 
-	&:global(.yellow) {
-		--c: rgb(255 196 0 / 15%);
-		background-image: linear-gradient(45deg, var(--c) 16.67%, transparent 16.67%, transparent 50%, var(--c) 50%, var(--c) 66.67%, transparent 66.67%, transparent 100%);
-		background-size: 16px 16px;
-	}
+		&.isSuspended {
+			--c: color(from color-mix(in srgb, var(--panel), white 15%) srgb r g b / 0.5);
+		}
 
-	&:global(.red) {
-		--c: rgb(255 0 0 / 15%);
-		background-image: linear-gradient(45deg, var(--c) 16.67%, transparent 16.67%, transparent 50%, var(--c) 50%, var(--c) 66.67%, transparent 66.67%, transparent 100%);
-		background-size: 16px 16px;
+		&.isBlocked {
+			--c: color(from color-mix(in srgb, var(--panel), red 50%) srgb r g b / 0.5);
+		}
 	}
+}
 
-	&:global(.gray) {
-		--c: var(--bg);
-		background-image: linear-gradient(45deg, var(--c) 16.67%, transparent 16.67%, transparent 50%, var(--c) 50%, var(--c) 66.67%, transparent 66.67%, transparent 100%);
-		background-size: 16px 16px;
-	}
+.icon {
+	display: block;
+	width: ($bodyTitleHieght + $bodyInfoHieght);
+	height: ($bodyTitleHieght + $bodyInfoHieght);
+	object-fit: cover;
+	border-radius: 4px;
+	margin-right: 12px;
+}
+
+.body {
+	flex: 1;
+	overflow: hidden;
+	font-size: 0.9em;
+	color: var(--fg);
+	padding-right: 8px;
+}
+
+.host {
+	display: block;
+	width: 100%;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	line-height: $bodyTitleHieght;
+}
+
+.sub {
+	display: block;
+	width: 100%;
+	font-size: 80%;
+	opacity: 0.7;
+	line-height: $bodyInfoHieght;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.chart {
+	height: 30px;
 }
 </style>

--- a/packages/frontend/src/components/MkMediaImage.vue
+++ b/packages/frontend/src/components/MkMediaImage.vue
@@ -167,13 +167,6 @@ const imageUrlRef = computed(() => {
 	return imageRef.value.thumbnailUrl;
 });
 
-const reactiveColor = computed(() => {
-	if (defaultStore.reactiveState.darkMode.value) {
-		return 'rgba(255, 255, 255, 0.02)';
-	}
-	return 'rgba(0, 0, 0, 0.02)';
-});
-
 const showImage = async () => {
 	if (!props.controls || !hideRef.value) return;
 	if (sensitiveRef.value && defaultStore.state.confirmWhenRevealingSensitiveMedia) {
@@ -220,17 +213,22 @@ const showImageMenu = (ev: MouseEvent) => {
 
 .rootVisible {
 	background-color: var(--bg);
-	background-image: linear-gradient(
-		45deg,
-		v-bind(reactiveColor) 16.67%,
-		var(--bg) 16.67%,
-		var(--bg) 50%,
-		v-bind(reactiveColor) 50%,
-		v-bind(reactiveColor) 66.67%,
-		var(--bg) 66.67%,
-		var(--bg) 100%
+	background-image: repeating-linear-gradient(
+		135deg,
+		transparent,
+		transparent 10px,
+		var(--c) 6px,
+		var(--c) 16px
 	);
-	background-size: 16px 16px;
+
+	&,
+	html[data-color-scheme=light] & {
+		--c: color(from color-mix(in srgb, var(--bg), black 15%) srgb r g b / 0.25);
+	}
+
+	html[data-color-scheme=dark] & {
+		--c: color(from color-mix(in srgb, var(--bg), white 15%) srgb r g b / 0.5);
+	}
 }
 
 .rootSensitive {

--- a/packages/frontend/src/components/MkMediaVideo.vue
+++ b/packages/frontend/src/components/MkMediaVideo.vue
@@ -180,13 +180,6 @@ const {
 	reactiveIAmOwner: iAmOwnerRef,
 } = useReactiveDriveFile(() => props.video);
 
-const reactiveColor = computed(() => {
-	if (defaultStore.reactiveState.darkMode.value) {
-		return 'rgba(255, 255, 255, 0.02)';
-	}
-	return 'rgba(0, 0, 0, 0.02)';
-});
-
 const showVideo = async () => {
 	if (!hideRef.value) return;
 	if (sensitiveRef.value && defaultStore.state.confirmWhenRevealingSensitiveMedia) {
@@ -538,17 +531,22 @@ onDeactivated(() => {
 
 .rootVisible {
 	background-color: var(--bg);
-	background-image: linear-gradient(
-		45deg,
-		v-bind(reactiveColor) 16.67%,
-		var(--bg) 16.67%,
-		var(--bg) 50%,
-		v-bind(reactiveColor) 50%,
-		v-bind(reactiveColor) 66.67%,
-		var(--bg) 66.67%,
-		var(--bg) 100%
+	background-image: repeating-linear-gradient(
+		135deg,
+		transparent,
+		transparent 10px,
+		var(--c) 6px,
+		var(--c) 16px
 	);
-	background-size: 16px 16px;
+
+	&,
+	html[data-color-scheme=light] & {
+		--c: color(from color-mix(in srgb, var(--bg), black 15%) srgb r g b / 0.25);
+	}
+
+	html[data-color-scheme=dark] & {
+		--c: color(from color-mix(in srgb, var(--bg), white 15%) srgb r g b / 0.5);
+	}
 }
 
 .rootSensitive {

--- a/packages/frontend/src/components/MkNoteDetailed.vue
+++ b/packages/frontend/src/components/MkNoteDetailed.vue
@@ -167,7 +167,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 				<template #default="{ items }">
 					<div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(270px, 1fr)); gap: 12px;">
 						<MkA v-for="item in items" :key="item.id" :to="userPage(item.user)">
-							<MkUserCardMini :user="item.user" :withChart="false"/>
+							<MkUserCardMini :user="item.user"/>
 						</MkA>
 					</div>
 				</template>
@@ -184,7 +184,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 				<template #default="{ items }">
 					<div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(270px, 1fr)); gap: 12px;">
 						<MkA v-for="item in items" :key="item.id" :to="userPage(item.user)">
-							<MkUserCardMini :user="item.user" :withChart="false"/>
+							<MkUserCardMini :user="item.user"/>
 						</MkA>
 					</div>
 				</template>
@@ -208,6 +208,7 @@ import { type ComputedRef, computed, inject, onMounted, provide, ref, shallowRef
 import * as mfm from 'mfm-js';
 import * as Misskey from 'misskey-js';
 import { isLink } from '@@/js/is-link.js';
+import { host } from '@@/js/config.js';
 import MkNoteSub from '@/components/MkNoteSub.vue';
 import MkNoteSimple from '@/components/MkNoteSimple.vue';
 import MkReactionsViewer from '@/components/MkReactionsViewer.vue';
@@ -231,7 +232,6 @@ import { reactionPicker } from '@/scripts/reaction-picker.js';
 import { extractUrlFromMfm } from '@/scripts/extract-url-from-mfm.js';
 import { $i } from '@/account.js';
 import { i18n } from '@/i18n.js';
-import { host } from '@@/js/config.js';
 import { getNoteClipMenu, getNoteMenu, getRenoteMenu } from '@/scripts/get-note-menu.js';
 import { useNoteCapture } from '@/scripts/use-note-capture.js';
 import { deepClone } from '@/scripts/clone.js';

--- a/packages/frontend/src/components/MkPostForm.vue
+++ b/packages/frontend/src/components/MkPostForm.vue
@@ -1221,15 +1221,22 @@ defineExpose({
 	min-height: 75px;
 	max-height: 150px;
 	overflow: auto;
-	background-size: auto auto;
-}
+	background-image: repeating-linear-gradient(
+		135deg,
+		transparent,
+		transparent 10px,
+		var(--c) 6px,
+		var(--c) 16px
+	);
 
-html[data-color-scheme=dark] .preview {
-	background-image: repeating-linear-gradient(135deg, transparent, transparent 5px, #0004 5px, #0004 10px);
-}
+	&,
+	html[data-color-scheme=light] & {
+		--c: rgb(0 0 0 / 0.02);
+	}
 
-html[data-color-scheme=light] .preview {
-	background-image: repeating-linear-gradient(135deg, transparent, transparent 5px, #00000005 5px, #00000005 10px);
+	html[data-color-scheme=dark] & {
+		--c: rgb(255 255 255 / 0.02);
+	}
 }
 
 .targetNote {

--- a/packages/frontend/src/components/MkUserCardMini.vue
+++ b/packages/frontend/src/components/MkUserCardMini.vue
@@ -4,7 +4,12 @@ SPDX-License-Identifier: AGPL-3.0-only
 -->
 
 <template>
-<div v-adaptive-bg :class="[$style.root]">
+<div
+	:class="[$style.root, {
+		[$style.isSilenced]: 'isSilenced' in user && user.isSilenced,
+		[$style.isSuspended]: 'isSuspended' in user && user.isSuspended,
+	}]"
+>
 	<MkAvatar :class="$style.avatar" :user="user" indicator/>
 	<div :class="$style.body">
 		<span :class="$style.name"><MkUserName :user="user"/></span>
@@ -15,29 +20,42 @@ SPDX-License-Identifier: AGPL-3.0-only
 </template>
 
 <script lang="ts" setup>
+import { shallowRef, watch } from 'vue';
 import * as Misskey from 'misskey-js';
-import { onMounted, ref } from 'vue';
-import MkMiniChart from '@/components/MkMiniChart.vue';
 import { misskeyApiGet } from '@/scripts/misskey-api.js';
 import { acct } from '@/filters/user.js';
+import MkMiniChart from '@/components/MkMiniChart.vue';
 
 const props = withDefaults(defineProps<{
 	user: Misskey.entities.User;
-	withChart: boolean;
+	withChart?: boolean;
 }>(), {
-	withChart: true,
+	withChart: false,
 });
 
-const chartValues = ref<number[] | null>(null);
+const chartValues = shallowRef<number[] | null>(null);
 
-onMounted(() => {
-	if (props.withChart) {
-		misskeyApiGet('charts/user/notes', { userId: props.user.id, limit: 16 + 1, span: 'day' }).then(res => {
+watch([
+	() => props.user.id,
+	() => props.withChart,
+], ([userId, withChart]) => {
+	if (withChart) {
+		misskeyApiGet('charts/user/notes', {
+			userId,
+			limit: 16 + 1,
+			span: 'day',
+		}).then(res => {
 			// 今日のぶんの値はまだ途中の値であり、それも含めると大抵の場合前日よりも下降しているようなグラフになってしまうため今日は弾く
-			res.inc.splice(0, 1);
+			res.inc.shift();
 			chartValues.value = res.inc;
+		}).catch(() => {
+			chartValues.value = null;
 		});
+	} else {
+		chartValues.value = null;
 	}
+}, {
+	immediate: true,
 });
 </script>
 
@@ -49,8 +67,37 @@ $bodyInfoHieght: 16px;
 	display: flex;
 	align-items: center;
 	padding: 16px;
-	background: var(--panel);
 	border-radius: 8px;
+	background-color: var(--panel);
+	background-image: repeating-linear-gradient(
+		135deg,
+		transparent,
+		transparent 10px,
+		var(--c) 6px,
+		var(--c) 16px
+	);
+	--c: transparent;
+
+	&,
+	html[data-color-scheme=light] & {
+		&.isSilenced {
+			--c: color(from color-mix(in srgb, var(--panel), blue 50%) srgb r g b / 0.25);
+		}
+
+		&.isSuspended {
+			--c: color(from color-mix(in srgb, var(--panel), black 15%) srgb r g b / 0.25);
+		}
+	}
+
+	html[data-color-scheme=dark] & {
+		&.isSilenced {
+			--c: color(from color-mix(in srgb, var(--panel), blue 50%) srgb r g b / 0.5);
+		}
+
+		&.isSuspended {
+			--c: color(from color-mix(in srgb, var(--panel), white 15%) srgb r g b / 0.5);
+		}
+	}
 }
 
 .avatar {

--- a/packages/frontend/src/components/global/MkAd.vue
+++ b/packages/frontend/src/components/global/MkAd.vue
@@ -123,8 +123,22 @@ function reduceFrequency(): void {
 
 <style lang="scss" module>
 .root {
-	background-size: auto auto;
-	background-image: repeating-linear-gradient(45deg, transparent, transparent 8px, var(--ad) 8px, var(--ad) 14px );
+	background-image: repeating-linear-gradient(
+		135deg,
+		transparent,
+		transparent 10px,
+		var(--c) 6px,
+		var(--c) 16px
+	);
+
+	&,
+	html[data-color-scheme=light] & {
+		--c: rgb(0 0 0 / 0.02);
+	}
+
+	html[data-color-scheme=dark] & {
+		--c: rgb(255 255 255 / 0.02);
+	}
 }
 
 .main {

--- a/packages/frontend/src/components/global/MkFooterSpacer.vue
+++ b/packages/frontend/src/components/global/MkFooterSpacer.vue
@@ -4,12 +4,8 @@ SPDX-License-Identifier: AGPL-3.0-only
 -->
 
 <template>
-<div :class="[$style.spacer, defaultStore.reactiveState.darkMode.value ? $style.dark : $style.light]"></div>
+<div :class="$style.spacer"></div>
 </template>
-
-<script lang="ts" setup>
-import { defaultStore } from '@/store.js';
-</script>
 
 <style lang="scss" module>
 .spacer {
@@ -18,15 +14,21 @@ import { defaultStore } from '@/store.js';
 	margin: 0 auto;
 	height: 300px;
 	background-clip: content-box;
-	background-size: auto auto;
-	background-color: rgba(255, 255, 255, 0);
+	background-image: repeating-linear-gradient(
+		135deg,
+		transparent,
+		transparent 10px,
+		var(--c) 6px,
+		var(--c) 16px
+	);
 
-	&.light {
-		background-image: repeating-linear-gradient(135deg, transparent, transparent 16px, #00000010 16px, #00000010 20px );
+	&,
+	html[data-color-scheme=light] & {
+		--c: rgb(0 0 0 / 0.02);
 	}
 
-	&.dark {
-		background-image: repeating-linear-gradient(135deg, transparent, transparent 16px, #FFFFFF16 16px, #FFFFFF16 20px );
+	html[data-color-scheme=dark] & {
+		--c: rgb(255 255 255 / 0.02);
 	}
 }
 </style>

--- a/packages/frontend/src/components/global/MkPageHeader.vue
+++ b/packages/frontend/src/components/global/MkPageHeader.vue
@@ -4,7 +4,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 -->
 
 <template>
-<div v-if="show" ref="el" :class="[$style.root]" :style="{ background: bg }">
+<div v-if="show" ref="el" :class="[$style.root]">
 	<div :class="[$style.upper, { [$style.slim]: narrow, [$style.thin]: thin_ }]">
 		<div v-if="!thin_ && narrow && props.displayMyAvatar && $i" class="_button" :class="$style.buttonsLeft" @click="openAccountMenu">
 			<MkAvatar :class="$style.avatar" :user="$i"/>
@@ -64,11 +64,9 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 <script lang="ts" setup>
 import { onMounted, onUnmounted, ref, inject, shallowRef, computed } from 'vue';
-import tinycolor from 'tinycolor2';
 import { scrollToTop } from '@@/js/scroll.js';
 import XTabs, { Tab } from './MkPageHeader.tabs.vue';
 import type { PageHeaderItem } from '@/types/page-header.js';
-import { globalEvents } from '@/events.js';
 import { injectReactiveMetadata } from '@/scripts/page-metadata.js';
 import { $i, openAccountMenu as openAccountMenu_ } from '@/account.js';
 import MkButton from '@/components/MkButton.vue';
@@ -95,7 +93,6 @@ const hideTitle = inject<boolean>('shouldOmitHeaderTitle', false);
 const thin_ = props.thin || inject<boolean>('shouldHeaderThin', false);
 
 const el = shallowRef<HTMLElement | undefined>(undefined);
-const bg = ref<string | undefined>(undefined);
 const narrow = ref(false);
 const hasTabs = computed(() => props.tabs.length > 0);
 const hasActions = computed(() => props.actions && props.actions.length > 0);
@@ -119,19 +116,9 @@ function onTabClick(): void {
 	top();
 }
 
-const calcBg = () => {
-	const rawBg = 'var(--bg)';
-	const tinyBg = tinycolor(rawBg.startsWith('var(') ? getComputedStyle(document.documentElement).getPropertyValue(rawBg.slice(4, -1)) : rawBg);
-	tinyBg.setAlpha(0.85);
-	bg.value = tinyBg.toRgbString();
-};
-
 let ro: ResizeObserver | null;
 
 onMounted(() => {
-	calcBg();
-	globalEvents.on('themeChanged', calcBg);
-
 	if (el.value && el.value.parentElement) {
 		narrow.value = el.value.parentElement.offsetWidth < 500;
 		ro = new ResizeObserver(() => {
@@ -144,7 +131,6 @@ onMounted(() => {
 });
 
 onUnmounted(() => {
-	globalEvents.off('themeChanged', calcBg);
 	if (ro) ro.disconnect();
 });
 </script>
@@ -155,6 +141,7 @@ onUnmounted(() => {
 	backdrop-filter: var(--blur, blur(15px));
 	border-bottom: solid 0.5px var(--divider);
 	width: 100%;
+	background: color(from var(--bg) srgb r g b / 0.85);
 }
 
 .upper,

--- a/packages/frontend/src/pages/admin-file.vue
+++ b/packages/frontend/src/pages/admin-file.vue
@@ -34,7 +34,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 				</MkKeyValue>
 			</div>
 			<MkA v-if="file.user" class="user" :to="`/admin/user/${file.user.id}`">
-				<MkUserCardMini :user="file.user"/>
+				<MkUserCardMini :user="file.user" withChart/>
 			</MkA>
 			<div>
 				<MkSwitch v-model="isSensitive" @update:modelValue="toggleIsSensitive">{{ i18n.ts.sensitive }}</MkSwitch>

--- a/packages/frontend/src/pages/admin/overview.users.vue
+++ b/packages/frontend/src/pages/admin/overview.users.vue
@@ -9,7 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 		<MkLoading v-if="fetching"/>
 		<div v-else class="users">
 			<MkA v-for="user in newUsers" :key="user.id" :to="`/admin/user/${user.id}`" class="user">
-				<MkUserCardMini :user="user"/>
+				<MkUserCardMini :user="user" withChart/>
 			</MkA>
 		</div>
 	</Transition>

--- a/packages/frontend/src/pages/admin/roles.role.vue
+++ b/packages/frontend/src/pages/admin/roles.role.vue
@@ -37,7 +37,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 								<div v-for="item in items" :key="item.user.id" :class="[$style.userItem, { [$style.userItemOpend]: expandedItems.includes(item.id) }]">
 									<div :class="$style.userItemMain">
 										<MkA :class="$style.userItemMainBody" :to="`/admin/user/${item.user.id}`">
-											<MkUserCardMini :user="item.user"/>
+											<MkUserCardMini :user="item.user" withChart/>
 										</MkA>
 										<button class="_button" :class="$style.userToggle" @click="toggleItem(item)"><i :class="$style.chevron" class="ti ti-chevron-down"></i></button>
 										<button class="_button" :class="$style.unassign" @click="unassign(item.user, $event)"><i class="ti ti-x"></i></button>

--- a/packages/frontend/src/pages/admin/users.vue
+++ b/packages/frontend/src/pages/admin/users.vue
@@ -45,7 +45,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 			<MkPagination v-slot="{items}" ref="paginationComponent" :pagination="pagination">
 				<div :class="$style.users">
 					<MkA v-for="user in items" :key="user.id" v-tooltip.mfm="`Last posted: ${dateString(user.updatedAt)}`" :class="$style.user" :to="`/admin/user/${user.id}`">
-						<MkUserCardMini :user="user"/>
+						<MkUserCardMini :user="user" withChart/>
 					</MkA>
 				</div>
 			</MkPagination>

--- a/packages/frontend/src/pages/instance-info.vue
+++ b/packages/frontend/src/pages/instance-info.vue
@@ -119,7 +119,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 			<div v-else-if="tab === 'users'" key="users" class="_gaps_m">
 				<MkPagination v-slot="{items}" :pagination="usersPagination" style="display: grid; grid-template-columns: repeat(auto-fill,minmax(270px,1fr)); gap: 12px;">
 					<MkA v-for="user in items" :key="user.id" v-tooltip.mfm="`Last posted: ${dateString(user.updatedAt)}`" class="user" :to="`/admin/user/${user.id}`">
-						<MkUserCardMini :user="user"/>
+						<MkUserCardMini :user="user" withChart/>
 					</MkA>
 				</MkPagination>
 			</div>

--- a/packages/frontend/src/pages/list.vue
+++ b/packages/frontend/src/pages/list.vue
@@ -21,7 +21,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 			<div class="_gaps_s">
 				<div v-for="user in users" :key="user.id" :class="$style.userItem">
 					<MkA :class="$style.userItemBody" :to="`${userPage(user)}`">
-						<MkUserCardMini :user="user"/>
+						<MkUserCardMini :user="user" withChart/>
 					</MkA>
 				</div>
 			</div>

--- a/packages/frontend/src/pages/my-lists/list.vue
+++ b/packages/frontend/src/pages/my-lists/list.vue
@@ -36,7 +36,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 								<div v-for="item in items" :key="item.id">
 									<div :class="$style.userItem">
 										<MkA :class="$style.userItemBody" :to="`${userPage(item.user)}`">
-											<MkUserCardMini :user="item.user"/>
+											<MkUserCardMini :user="item.user" withChart/>
 										</MkA>
 										<button class="_button" :class="$style.menu" @click="showMembershipMenu(item, $event)"><i class="ti ti-dots"></i></button>
 										<button class="_button" :class="$style.remove" @click="removeUser(item, $event)"><i class="ti ti-x"></i></button>

--- a/packages/frontend/src/pages/search.note.vue
+++ b/packages/frontend/src/pages/search.note.vue
@@ -70,7 +70,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 							<div style="overflow: hidden;">
 								<MkUserCardMini
 									:user="user"
-									:withChart="false"
 									:class="$style.userSelectedCard"
 								/>
 							</div>

--- a/packages/frontend/src/pages/settings/accounts.vue
+++ b/packages/frontend/src/pages/settings/accounts.vue
@@ -15,7 +15,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 						<MkButton @click="init"><i class="ti ti-refresh"></i> {{ i18n.ts.reloadAccountsList }}</MkButton>
 					</div>
 
-					<MkUserCardMini v-for="user in accounts" :key="user.id" :user="user" :class="$style.user" @click.prevent="menu(user, $event)"/>
+					<MkUserCardMini v-for="user in accounts" :key="user.id" :user="user" withChart :class="$style.user" @click.prevent="menu(user, $event)"/>
 				</div>
 			</FormSuspense>
 		</div>

--- a/packages/frontend/src/style.scss
+++ b/packages/frontend/src/style.scss
@@ -455,14 +455,17 @@ rt {
 	box-shadow: 0 6px 16px #0007, 0 0 1px 1px #693410, inset 0 0 2px 1px #ce8a5c;
 	border-radius: 10px;
 
-	--bg: #F1E8DC;
-	--fg: #693410;
-}
+	&,
+	html[data-color-scheme=light] & {
+		--bg: #F1E8DC;
+		--fg: #693410;
+	}
 
-html[data-color-scheme=dark] ._woodenFrame {
-	--bg: #1d0c02;
-	--fg: #F1E8DC;
-	--panel: #192320;
+	html[data-color-scheme=dark] & {
+		--bg: #1d0c02;
+		--fg: #F1E8DC;
+		--panel: #192320;
+	}
 }
 
 ._woodenFrameH {


### PR DESCRIPTION
## What

- refactor: 斜線デザイン目的で linear-gradientを利用している箇所すべてを repeating-linear-gradient に変更
- enhance: 通報一覧とかで使われるコンポーネントで、アカウントの状態を視覚的に確認できるように変更

<img width="384" alt="ライトモード時のMkUserCardMini" src="https://github.com/user-attachments/assets/8daf3413-8c50-4cf6-a484-87b996d66cad">
<img width="384" alt="ダークモード時のMkUserCardMini" src="https://github.com/user-attachments/assets/f9962e56-2c31-4d48-b79b-d64728027570">

## Why

## Additional info (optional)

## Checklist
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If possible) Add tests
